### PR TITLE
meson: Copy headers using copy kwarg

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project('libxmlb', 'c',
   version : '0.1.3',
   license : 'LGPL-2.1+',
-  meson_version : '>=0.46.0',
+  meson_version : '>=0.47.0',
   default_options : ['warning_level=2', 'c_std=c99'],
 )
 

--- a/src/libxmlb/meson.build
+++ b/src/libxmlb/meson.build
@@ -3,7 +3,7 @@
 # until https://github.com/mesonbuild/meson/issues/2546 is fixed
 foreach header : xb_headers
   configure_file(
-    configuration : configuration_data(),
+    copy : true,
     input : header,
     output : '@PLAINNAME@',
   )


### PR DESCRIPTION
Meson 0.47 introduces copy kwarg [1] to configure_file, allowing us to copy files to build directory in a slightly cleaner way than passing an empty configuration_data() object.

It is still a hack before install_headers can copy files to subdir in the build directory. [2]

[1]: http://mesonbuild.com/Reference-manual.html#configure_file
[2]: https://github.com/mesonbuild/meson/issues/2546