### PR TITLE
Fix compiling on Ubuntu Xenial

### DIFF
--- a/src/xb-machine.c
+++ b/src/xb-machine.c
@@ -11,6 +11,10 @@
 #include <gio/gio.h>
 #include <string.h>
 
+#if !GLIB_CHECK_VERSION(2,54,0)
+#include <errno.h>
+#endif
+
 #include "xb-machine.h"
 #include "xb-opcode.h"
 #include "xb-string-private.h"
@@ -259,6 +263,72 @@ xb_machine_parse_add_func (XbMachine *self,
 	g_ptr_array_add (opcodes, xb_opcode_func_new (item->idx));
 	return TRUE;
 }
+
+#if !GLIB_CHECK_VERSION(2,54,0)
+static gboolean
+str_has_sign (const gchar *str)
+{
+	return str[0] == '-' || str[0] == '+';
+}
+
+static gboolean
+str_has_hex_prefix (const gchar *str)
+{
+	return str[0] == '0' && g_ascii_tolower (str[1]) == 'x';
+}
+
+static gboolean
+g_ascii_string_to_unsigned (const gchar *str,
+			    guint base,
+			    guint64 min,
+			    guint64 max,
+			    guint64 *out_num,
+			    GError **error)
+{
+	const gchar *end_ptr = NULL;
+	gint saved_errno = 0;
+	guint64 number;
+
+	g_return_val_if_fail (str != NULL, FALSE);
+	g_return_val_if_fail (base >= 2 && base <= 36, FALSE);
+	g_return_val_if_fail (min <= max, FALSE);
+	g_return_val_if_fail (error == NULL || *error == NULL, FALSE);
+
+	if (str[0] == '\0') {
+		g_set_error_literal (error,
+				     G_IO_ERROR, G_IO_ERROR_INVALID_DATA,
+				     "Empty string is not a number");
+		return FALSE;
+	}
+
+	errno = 0;
+	number = g_ascii_strtoull (str, (gchar **)&end_ptr, base);
+	saved_errno = errno;
+
+	if (g_ascii_isspace (str[0]) || str_has_sign (str) ||
+	    (base == 16 && str_has_hex_prefix (str)) ||
+	    (saved_errno != 0 && saved_errno != ERANGE) ||
+	    end_ptr == NULL ||
+	    *end_ptr != '\0') {
+		g_set_error (error,
+			     G_IO_ERROR, G_IO_ERROR_INVALID_DATA,
+			     "“%s” is not an unsigned number", str);
+		return FALSE;
+	}
+	if (saved_errno == ERANGE || number < min || number > max) {
+		g_autofree gchar *min_str = g_strdup_printf ("%" G_GUINT64_FORMAT, min);
+		g_autofree gchar *max_str = g_strdup_printf ("%" G_GUINT64_FORMAT, max);
+		g_set_error (error,
+			     G_IO_ERROR, G_IO_ERROR_INVALID_DATA,
+			     "Number “%s” is out of bounds [%s, %s]",
+			     str, min_str, max_str);
+		return FALSE;
+	}
+	if (out_num != NULL)
+		*out_num = number;
+	return TRUE;
+}
+#endif
 
 static gboolean
 xb_machine_parse_add_text_raw (XbMachine *self,


### PR DESCRIPTION
Include a local copy of g_ascii_string_to_unsigned() to avoid raising the GLib
dep to what's available in Ubuntu 16.04.

Fixes https://github.com/hughsie/libxmlb/issues/3

@superm1 -- can you try this without too much work? If it makes it easier, feel free to cherry pick onto wip/subproject