### PR TITLE
Don't hardcode the path of python3

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -123,6 +123,9 @@ configure_file(
   configuration : conf
 )
 
+python = import('python')
+python3 = python.find_installation('python3')
+
 subdir('src')
 if get_option('gtkdoc')
   gtkdocscan = find_program('gtkdoc-scan', required : true)

--- a/src/generate-version-script.py
+++ b/src/generate-version-script.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python3
 # pylint: disable=invalid-name,missing-docstring
 #
 # Copyright (C) 2017 Richard Hughes <richard@hughsie.com>

--- a/src/meson.build
+++ b/src/meson.build
@@ -162,6 +162,7 @@ if get_option('introspection')
     input: gir[0],
     output: 'libxmlb.map',
     command: [
+      python3,
       join_paths(meson.current_source_dir(), 'generate-version-script.py'),
       'LIBXMLB',
       '@INPUT@',


### PR DESCRIPTION
Most *BSD systems don't consider python as an integral part of the
operating system, so python is seldom installed in /usr prefix.

This fixes gnome-software build on FreeBSD:
```
[38/259] Generating libxmlb-mapfile with a custom command.
FAILED: subprojects/libxmlb/src/libxmlb.map
/home/lantw44/gnome/source/gnome-software/subprojects/libxmlb/src/generate-version-script.py LIBXMLB subprojects/libxmlb/src/Xmlb-1.0.gir subprojects/libxmlb/src/libxmlb.map
/bin/sh: /home/lantw44/gnome/source/gnome-software/subprojects/libxmlb/src/generate-version-script.py: not found
```