### PR TITLE
libxmlb: Treat text/plain as MIME for xml

### DIFF
--- a/src/xb-builder-source.c
+++ b/src/xb-builder-source.c
@@ -509,7 +509,7 @@ xb_builder_source_init (XbBuilderSource *self)
 
 	/* built-in types */
 	xb_builder_source_add_converter (self,
-					 "application/xml",
+					 "application/xml,text/plain",
 					 xb_builder_source_load_plain_cb,
 					 NULL, NULL);
 	xb_builder_source_add_converter (self,


### PR DESCRIPTION
.xml files in ChromeOS do not have the MIME type expected by the
library. Adding the MIME type that is currently reported on the files by
the OS in the list of MIME types handled by the library.