### PR TITLE
Add XB_BUILDER_COMPILE_FLAG_IGNORE_GUID

### DIFF
--- a/src/xb-builder.c
+++ b/src/xb-builder.c
@@ -896,7 +896,8 @@ xb_builder_ensure (XbBuilder *self, GFile *file, XbBuilderCompileFlags flags,
 		}
 
 		/* reload the cached silo with the new file data */
-		if (g_strcmp0 (xb_silo_get_guid (silo_tmp), guid) == 0) {
+		if (g_strcmp0 (xb_silo_get_guid (silo_tmp), guid) == 0 ||
+		    (flags & XB_BUILDER_COMPILE_FLAG_IGNORE_GUID) > 0) {
 			g_autoptr(GBytes) blob = xb_silo_get_bytes (silo_tmp);
 			g_debug ("loading silo with file contents");
 			if (!xb_silo_load_from_bytes (priv->silo, blob,

--- a/src/xb-builder.h
+++ b/src/xb-builder.h
@@ -38,6 +38,7 @@ struct _XbBuilderClass {
  * @XB_BUILDER_COMPILE_FLAG_IGNORE_INVALID:	Ignore invalid files without an error
  * @XB_BUILDER_COMPILE_FLAG_SINGLE_LANG:	Only store a single language
  * @XB_BUILDER_COMPILE_FLAG_WATCH_BLOB:		Watch the XMLB file for changes
+ * @XB_BUILDER_COMPILE_FLAG_IGNORE_GUID:	Ignore the cache GUID value
  *
  * The flags for converting to XML.
  **/
@@ -47,6 +48,7 @@ typedef enum {
 	XB_BUILDER_COMPILE_FLAG_IGNORE_INVALID	= 1 << 2,	/* Since: 0.1.0 */
 	XB_BUILDER_COMPILE_FLAG_SINGLE_LANG	= 1 << 3,	/* Since: 0.1.0 */
 	XB_BUILDER_COMPILE_FLAG_WATCH_BLOB	= 1 << 4,	/* Since: 0.1.0 */
+	XB_BUILDER_COMPILE_FLAG_IGNORE_GUID	= 1 << 5,	/* Since: 0.1.7 */
 	/*< private >*/
 	XB_BUILDER_COMPILE_FLAG_LAST
 } XbBuilderCompileFlags;


### PR DESCRIPTION
This allows us to load from a silo without caring about the exact GUID.
This may be useful if the cache keys are not the same for some reason.
