### PR TITLE
Allow compilation on older versions of meson

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project('libxmlb', 'c',
   version : '0.1.8',
   license : 'LGPL-2.1+',
-  meson_version : '>=0.47.0',
+  meson_version : '>=0.45.0',
   default_options : ['warning_level=2', 'c_std=c99'],
 )
 
@@ -90,8 +90,14 @@ test_link_args = [
   '-Wl,-z,now',
 ]
 foreach link_arg: test_link_args
-  if cc.has_link_argument(link_arg)
-    global_link_args += link_arg
+  if meson.version().version_compare('>=0.46.0')
+    if cc.has_link_argument(link_arg)
+      global_link_args += link_arg
+    endif
+  else
+    if cc.has_argument(link_arg)
+      global_link_args += link_arg
+    endif
   endif
 endforeach
 add_project_link_arguments(
@@ -131,8 +137,12 @@ configure_file(
   configuration : conf
 )
 
-python = import('python')
-python3 = python.find_installation('python3')
+if meson.version().version_compare('>=0.46.0')
+  python = import('python')
+  python3 = python.find_installation('python3')
+else
+  python3 = find_program('python3')
+endif
 
 subdir('src')
 if get_option('gtkdoc')

--- a/src/libxmlb/meson.build
+++ b/src/libxmlb/meson.build
@@ -2,9 +2,17 @@
 # in order for including the headers from parent projects to work
 # until https://github.com/mesonbuild/meson/issues/2546 is fixed
 foreach header : xb_headers
-  configure_file(
-    copy : true,
-    input : header,
-    output : '@PLAINNAME@',
-  )
+  if meson.version().version_compare('>=0.47.0')
+    configure_file(
+      copy : true,
+      input : header,
+      output : '@PLAINNAME@',
+    )
+  else
+    configure_file(
+      configuration : configuration_data(),
+      input : header,
+      output : '@PLAINNAME@',
+    )
+  endif
 endforeach


### PR DESCRIPTION
There is a general agreement to bring fwupd 1.2.x into Ubuntu 18.04, so I'm sorting out some of the changes needed for this.

This reverts commit 96437763b2b179e402e2660c06a0036397c29fcd and makes adjustments to dynamically decide what to do based upon meson version.

This is intended to be used for backporting libxmlb to 18.04.


