### PR TITLE
Make sure to not reuse same GError when ignoring a parsing failure

### DIFF
--- a/src/xb-builder.c
+++ b/src/xb-builder.c
@@ -749,6 +749,7 @@ xb_builder_compile (XbBuilder *self, XbBuilderCompileFlags flags, GCancellable *
 				g_debug ("ignoring invalid file %s: %s",
 					 source_guid,
 					 error_local->message);
+				g_clear_error (&error_local);
 				continue;
 			}
 			g_propagate_prefixed_error (error,


### PR DESCRIPTION
Untested. I inspected the code to see what could be causing gnome-software issue https://gitlab.gnome.org/GNOME/gnome-software/issues/661 and found this. I think it's highly likely to be the root cause.