### PR TITLE
build: Update the required version of Meson

### DIFF
--- a/contrib/ci/Dockerfile-debian
+++ b/contrib/ci/Dockerfile-debian
@@ -8,9 +8,16 @@ RUN apt-get install -yq --no-install-recommends \
 	libgirepository1.0-dev \
 	libglib2.0-dev \
 	libstemmer-dev \
+	ninja-build \
+	python3-pip \
+	python3-setuptools \
+	python3-wheel \
 	shared-mime-info \
 	uuid-dev \
-	meson \
 	pkg-config
+
+# Meson is too old in unstable, and that won't change until Buster is released
+RUN pip3 install meson
+
 RUN mkdir /build
 WORKDIR /build

--- a/contrib/ci/Dockerfile-fedora
+++ b/contrib/ci/Dockerfile-fedora
@@ -1,4 +1,4 @@
-FROM fedora:28
+FROM fedora:30
 
 RUN dnf -y update
 RUN dnf -y install \

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project('libxmlb', 'c',
   version : '0.1.10',
   license : 'LGPL-2.1+',
-  meson_version : '>=0.47.0',
+  meson_version : '>=0.50.0',
   default_options : ['warning_level=2', 'c_std=c99'],
 )
 


### PR DESCRIPTION
Meson helpfully complains about the fact we required 0.46.0 but used
features only available in 0.50.0:

    WARNING: Project targetting '>=0.47.0' but tried to use feature introduced in '0.50.0': install arg in configure_file

This requires updating the CI to Fedora 30, which seems like a good idea anyway.