### PR TITLE
build: Conditionalize installation of test data

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -1,11 +1,13 @@
-configure_file(
-  input : 'libxmlb.test.in',
-  output : 'libxmlb.test',
-  configuration : conf,
-  install: true,
-  install_dir: join_paths('share', 'installed-tests', 'libxmlb'),
-)
+if get_option('tests')
+  configure_file(
+    input : 'libxmlb.test.in',
+    output : 'libxmlb.test',
+    configuration : conf,
+    install: true,
+    install_dir: join_paths('share', 'installed-tests', 'libxmlb'),
+  )
 
-install_data(['test.xml.gz.gz.gz'],
-  install_dir: join_paths('share', 'installed-tests', 'libxmlb'),
-)
+  install_data(['test.xml.gz.gz.gz'],
+    install_dir: join_paths('share', 'installed-tests', 'libxmlb'),
+  )
+endif


### PR DESCRIPTION
The tests themselves are only installed when requested, and so should
the test data.