### PR TITLE
A couple of CI improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,12 @@ dist: trusty
 services:
   - docker
 
+env:
+  - OS=debian
+  - OS=fedora
+
 before_script:
-  - docker build -t libxmlb-fedora -f contrib/ci/Dockerfile-fedora .
-  - docker build -t libxmlb-debian -f contrib/ci/Dockerfile-debian .
+  - docker build -t libxmlb-${OS} -f contrib/ci/Dockerfile-${OS} .
 
 script:
-  - docker run -t -v `pwd`:/build libxmlb-fedora ./contrib/ci/build_and_test.sh
-  - docker run -t -v `pwd`:/build libxmlb-debian ./contrib/ci/build_and_test.sh
+  - docker run -t -v `pwd`:/build libxmlb-${OS} ./contrib/ci/build_and_test.sh

--- a/contrib/ci/Dockerfile-debian
+++ b/contrib/ci/Dockerfile-debian
@@ -19,5 +19,4 @@ RUN apt-get install -yq --no-install-recommends \
 # Meson is too old in unstable, and that won't change until Buster is released
 RUN pip3 install meson
 
-RUN mkdir /build
 WORKDIR /build

--- a/contrib/ci/Dockerfile-fedora
+++ b/contrib/ci/Dockerfile-fedora
@@ -12,5 +12,4 @@ RUN dnf -y install \
 	shared-mime-info \
 	redhat-rpm-config
 
-RUN mkdir /build
 WORKDIR /build


### PR DESCRIPTION
This pull request makes the CI a bit nicer:

1. it removes an unnecessary operation from the Docker files;
2. it makes the jobs run in parallel on Debian and Fedora;

The most significant change is the latter, because it means testing libxmlb on other distros won't take longer to run, if everything runs in parallel.