### PR TITLE
trivial: use variables for installed tests paths

### DIFF
--- a/data/libxmlb.test.in
+++ b/data/libxmlb.test.in
@@ -1,3 +1,3 @@
 [Test]
 Type=session
-Exec=@libexecdir@/xb-self-test
+Exec=@installed_test_bindir@/xb-self-test

--- a/data/meson.build
+++ b/data/meson.build
@@ -4,10 +4,10 @@ if get_option('tests')
     output : 'libxmlb.test',
     configuration : conf,
     install: true,
-    install_dir: join_paths('share', 'installed-tests', 'libxmlb'),
+    install_dir: installed_test_datadir,
   )
 
   install_data(['test.xml.gz.gz.gz'],
-    install_dir: join_paths('share', 'installed-tests', 'libxmlb'),
+    install_dir: installed_test_datadir,
   )
 endif

--- a/meson.build
+++ b/meson.build
@@ -102,6 +102,9 @@ add_project_link_arguments(
 prefix = get_option('prefix')
 
 libexecdir = join_paths(prefix, get_option('libexecdir'))
+datadir = join_paths(prefix, get_option('datadir'))
+installed_test_bindir = join_paths(libexecdir, 'installed-tests', meson.project_name())
+installed_test_datadir = join_paths(datadir, 'installed-tests', meson.project_name())
 
 gio = dependency('gio-2.0', version : '>= 2.45.8')
 uuid = dependency('uuid')
@@ -124,7 +127,7 @@ endif
 
 gnome = import('gnome')
 
-conf.set('libexecdir', libexecdir)
+conf.set('installed_test_bindir', installed_test_bindir)
 conf.set_quoted('PACKAGE_NAME', meson.project_name())
 conf.set_quoted('VERSION', meson.project_version())
 configure_file(

--- a/src/meson.build
+++ b/src/meson.build
@@ -210,14 +210,14 @@ if get_option('tests')
     ],
     c_args : [
       '-DTESTDIR="@0@/../data"'.format(meson.current_source_dir()),
-      '-DINSTALLEDTESTDIR="' + join_paths('share', 'installed-tests', 'libxmlb') + '"',
+      '-DINSTALLEDTESTDIR="' + installed_test_datadir + '"',
     ],
     dependencies : [
       gio,
       libxmlb_dep,
     ],
     install : true,
-    install_dir : libexecdir
+    install_dir : installed_test_bindir
   )
   test('xb-self-test', e)
 endif


### PR DESCRIPTION
It is slightly cleaner and also it will be much easier for us to patch libxmlb to install them to a separate prefix.

It also fixes the issue that `INSTALLEDTESTDIR` was set to just `share/installed-tests/libxmlb` instead of the proper full path.