### PR TITLE
Do not use libuuid

### DIFF
--- a/contrib/ci/Dockerfile-debian
+++ b/contrib/ci/Dockerfile-debian
@@ -14,7 +14,6 @@ RUN apt-get install -yq --no-install-recommends \
 	python3-setuptools \
 	python3-wheel \
 	shared-mime-info \
-	uuid-dev \
 	pkg-config
 
 # Meson is too old in unstable, and that won't change until Buster is released

--- a/contrib/ci/Dockerfile-fedora
+++ b/contrib/ci/Dockerfile-fedora
@@ -9,7 +9,6 @@ RUN dnf -y install \
 	gtk-doc \
 	libabigail \
 	libstemmer-devel \
-	libuuid-devel \
 	meson \
 	shared-mime-info \
 	redhat-rpm-config

--- a/contrib/libxmlb.spec.in
+++ b/contrib/libxmlb.spec.in
@@ -13,7 +13,6 @@ Source0:   http://people.freedesktop.org/~hughsient/releases/%{name}-%{version}.
 BuildRequires: glib2-devel >= %{glib2_version}
 BuildRequires: gtk-doc
 BuildRequires: libstemmer-devel
-BuildRequires: libuuid-devel
 BuildRequires: meson
 BuildRequires: gobject-introspection-devel
 %if 0%{?rhel} == 7

--- a/meson.build
+++ b/meson.build
@@ -107,14 +107,9 @@ installed_test_bindir = join_paths(libexecdir, 'installed-tests', meson.project_
 installed_test_datadir = join_paths(datadir, 'installed-tests', meson.project_name())
 
 gio = dependency('gio-2.0', version : '>= 2.45.8')
-uuid = dependency('uuid')
-if cc.has_function('uuid_generate_sha1', args : '-luuid')
-  conf.set('HAVE_UUID_GENERATE_SHA1', '1')
-endif
 
 libxmlb_deps = [
   gio,
-  uuid,
 ]
 
 # support stemming of search tokens

--- a/src/xb-silo-private.h
+++ b/src/xb-silo-private.h
@@ -6,24 +6,19 @@
 
 #pragma once
 
-#include <uuid.h>
-
 #include "xb-machine.h"
 #include "xb-node.h"
 #include "xb-silo.h"
 
-G_BEGIN_DECLS
+#include "xb-string-private.h"
 
-/* for old versions of libuuid */
-#ifndef UUID_STR_LEN
-#define UUID_STR_LEN	37
-#endif
+G_BEGIN_DECLS
 
 /* 32 bytes, native byte order */
 typedef struct __attribute__ ((packed)) {
 	guint32		magic;
 	guint32		version;
-	uuid_t		guid;
+	XbGuid		guid;
 	guint16		strtab_ntags;
 	guint8		padding[2];
 	guint32		strtab;

--- a/src/xb-silo.c
+++ b/src/xb-silo.c
@@ -589,10 +589,10 @@ xb_silo_get_machine (XbSilo *self)
 gboolean
 xb_silo_load_from_bytes (XbSilo *self, GBytes *blob, XbSiloLoadFlags flags, GError **error)
 {
+	XbGuid guid_tmp;
 	XbSiloHeader *hdr;
 	XbSiloPrivate *priv = GET_PRIVATE (self);
 	gsize sz = 0;
-	gchar guid[UUID_STR_LEN] = { '\0' };
 	guint32 off = 0;
 	g_autoptr(GMutexLocker) locker = g_mutex_locker_new (&priv->nodes_mutex);
 	g_autoptr(GTimer) timer = g_timer_new ();
@@ -645,8 +645,8 @@ xb_silo_load_from_bytes (XbSilo *self, GBytes *blob, XbSiloLoadFlags flags, GErr
 	}
 
 	/* get GUID */
-	uuid_unparse (hdr->guid, guid);
-	priv->guid = g_strdup (guid);
+	memcpy (&guid_tmp, &hdr->guid, sizeof(guid_tmp));
+	priv->guid = xb_guid_to_string (&guid_tmp);
 
 	/* check strtab */
 	priv->strtab = hdr->strtab;

--- a/src/xb-string-private.h
+++ b/src/xb-string-private.h
@@ -21,5 +21,22 @@ gboolean	 xb_string_search			(const gchar	*text,
 gchar		*xb_string_xml_escape			(const gchar	*str);
 gboolean	 xb_string_isspace			(const gchar	*str,
 							 gssize		 strsz);
+typedef struct {
+	guint32	tlo;
+	guint16	tmi;
+	guint16	thi;
+	guint16	clo;
+	guint8	nde[6];
+} XbGuid;
+
+/* private namespace */
+#define XB_GUID_NS_DEFAULT		{ 0x59cea2b6, 0xf127, 0x3cd8, 0xb5f4, \
+					  { 0x5c, 0x02, 0x95, 0xa4, 0x15, 0x4a } }
+
+gchar		*xb_guid_to_string			(XbGuid		*guid);
+void		 xb_guid_compute_for_data		(XbGuid		*out,
+							 const XbGuid	*ns,
+							 const guint8	*buf,
+							 gsize		 bufsz);
 
 G_END_DECLS

--- a/src/xb-string.c
+++ b/src/xb-string.c
@@ -223,3 +223,32 @@ xb_string_isspace (const gchar *str, gssize strsz)
 	}
 	return TRUE;
 }
+
+void
+xb_guid_compute_for_data (XbGuid *out, const XbGuid *ns, const guint8 *buf, gsize bufsz)
+{
+	guint8 buf_tmp[20];
+	gsize buf_tmpsz = sizeof(buf_tmp);
+	g_autoptr(GHmac) hmac = NULL;
+
+	g_return_if_fail (out != NULL);
+
+	hmac = g_hmac_new (G_CHECKSUM_SHA1, (const guchar *) &ns, sizeof(ns));
+	if (buf != NULL && bufsz != 0)
+		g_hmac_update (hmac, (const guchar *) buf, bufsz);
+	g_hmac_get_digest (hmac, buf_tmp, &buf_tmpsz);
+	memcpy (out, buf_tmp, sizeof(XbGuid));
+}
+
+gchar *
+xb_guid_to_string (XbGuid *guid)
+{
+	return g_strdup_printf ("%08x-%04x-%04x-%04x-%02x%02x%02x%02x%02x%02x",
+				(guint) GUINT32_TO_BE (guid->tlo),
+				(guint) GUINT16_TO_BE (guid->tmi),
+				(guint) GUINT16_TO_BE (guid->thi),
+				(guint) GUINT16_TO_BE (guid->clo),
+				guid->nde[0], guid->nde[1],
+				guid->nde[2], guid->nde[3],
+				guid->nde[4], guid->nde[5]);
+}


### PR DESCRIPTION
We can drop a difficult-to-use dep using built-in methods. We don't actually
have to create a RFC4122-compliant UUID as we're only using this for checking
file validity, and the extra few bits of the HMAC should be useful.