### PR TITLE
Switch to the built-in distutils vercmp to drop an external dep

### DIFF
--- a/contrib/ci/Dockerfile-debian
+++ b/contrib/ci/Dockerfile-debian
@@ -11,7 +11,6 @@ RUN apt-get install -yq --no-install-recommends \
 	libstemmer-dev \
 	ninja-build \
 	python3-pip \
-	python3-setuptools \
 	python3-wheel \
 	shared-mime-info \
 	uuid-dev \

--- a/contrib/libxmlb.spec.in
+++ b/contrib/libxmlb.spec.in
@@ -15,11 +15,6 @@ BuildRequires: gtk-doc
 BuildRequires: libstemmer-devel
 BuildRequires: meson
 BuildRequires: gobject-introspection-devel
-%if 0%{?rhel} == 7
-BuildRequires: python36-setuptools
-%else
-BuildRequires: python-setuptools
-%endif
 
 # needed for the self tests
 BuildRequires: shared-mime-info

--- a/src/generate-version-script.py
+++ b/src/generate-version-script.py
@@ -8,7 +8,7 @@
 import sys
 import xml.etree.ElementTree as ET
 
-from pkg_resources import parse_version
+from distutils.version import StrictVersion
 
 XMLNS = '{http://www.gtk.org/introspection/core/1.0}'
 XMLNS_C = '{http://www.gtk.org/introspection/c/1.0}'
@@ -58,14 +58,14 @@ class LdVersionScript:
         for node in cls.findall(XMLNS + 'method'):
             version_tmp = self._add_node(node)
             if version_tmp:
-                if not version_lowest or parse_version(version_tmp) < parse_version(version_lowest):
+                if not version_lowest or StrictVersion(version_tmp) < StrictVersion(version_lowest):
                     version_lowest = version_tmp
 
         # add the constructor
         for node in cls.findall(XMLNS + 'constructor'):
             version_tmp = self._add_node(node)
             if version_tmp:
-                if not version_lowest or parse_version(version_tmp) < parse_version(version_lowest):
+                if not version_lowest or StrictVersion(version_tmp) < StrictVersion(version_lowest):
                     version_lowest = version_tmp
 
         # finally add the get_type symbol
@@ -93,7 +93,7 @@ class LdVersionScript:
         # output the version data to a file
         verout = '# generated automatically, do not edit!\n'
         oldversion = None
-        for version in sorted(versions, key=parse_version):
+        for version in sorted(versions, key=StrictVersion):
             symbols = sorted(self.releases[version])
             verout += '\n%s_%s {\n' % (self.library_name, version)
             verout += '  global:\n'


### PR DESCRIPTION
The root cause is that python-setuptools is not available in the RHEL 8.3
buildroot by default.