### PR TITLE
Don’t allocate opcodes individually

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ the text XML data where a lot of the tag content is duplicated, but can actually
 be larger than the original XML file. This isn't important; the fast query speed
 and the ability to mmap strings without copies more than makes up for the larger
 on-disk size. If you want to compress your XML, this library probably isn't for
-you -- just use gzip -- its gives you an almost a perfect compression ratio for
+you -- just use gzip -- it gives you an almost a perfect compression ratio for
 data like this.
 
 For example:

--- a/meson.build
+++ b/meson.build
@@ -27,7 +27,7 @@ configinc = include_directories('.')
 
 # get suported warning flags
 warning_flags = [
-  '-Waggregate-return',
+  '-Wno-aggregate-return',
   '-Wunused',
   '-Warray-bounds',
   '-Wcast-align',

--- a/src/libxmlb.map
+++ b/src/libxmlb.map
@@ -95,12 +95,6 @@ LIBXMLB_0.1.1 {
     xb_machine_parse;
     xb_machine_run;
     xb_machine_set_debug_flags;
-    xb_machine_stack_pop;
-    xb_machine_stack_push;
-    xb_machine_stack_push_integer;
-    xb_machine_stack_push_text;
-    xb_machine_stack_push_text_static;
-    xb_machine_stack_push_text_steal;
     xb_opcode_cmp_str;
     xb_opcode_cmp_val;
     xb_opcode_func_new;
@@ -145,8 +139,6 @@ LIBXMLB_0.1.3 {
     xb_machine_get_stack_size;
     xb_machine_set_stack_size;
     xb_stack_get_type;
-    xb_stack_pop;
-    xb_stack_push;
     xb_stack_push_steal;
   local: *;
 } LIBXMLB_0.1.2;
@@ -222,3 +214,22 @@ LIBXMLB_0.1.15 {
     xb_query_set_flags;
   local: *;
 } LIBXMLB_0.1.13;
+
+LIBXMLB_0.2.0 {
+  global:
+    xb_machine_opcode_func_init;
+    xb_machine_stack_pop;
+    xb_machine_stack_push;
+    xb_machine_stack_push_integer;
+    xb_machine_stack_push_text;
+    xb_machine_stack_push_text_static;
+    xb_machine_stack_push_text_steal;
+    xb_opcode_func_init;
+    xb_opcode_integer_init;
+    xb_opcode_text_init;
+    xb_opcode_text_init_static;
+    xb_opcode_text_init_steal;
+    xb_stack_pop;
+    xb_stack_push;
+  local: *;
+} LIBXMLB_0.1.15;

--- a/src/xb-builder-node.c
+++ b/src/xb-builder-node.c
@@ -67,6 +67,10 @@ xb_builder_node_add_flag (XbBuilderNode *self, XbBuilderNodeFlags flag)
 {
 	XbBuilderNodePrivate *priv = GET_PRIVATE (self);
 	g_return_if_fail (XB_IS_BUILDER_NODE (self));
+
+	if ((priv->flags & flag) != 0)
+		return;
+
 	priv->flags |= flag;
 	for (guint i = 0; i < priv->children->len; i++) {
 		XbBuilderNode *c = g_ptr_array_index (priv->children, i);

--- a/src/xb-machine.c
+++ b/src/xb-machine.c
@@ -122,6 +122,10 @@ xb_machine_add_operator (XbMachine *self, const gchar *str, const gchar *name)
  * Adds a new function to the virtual machine. Registered functions can then be
  * used as methods.
  *
+ * The @method_cb must not modify the stack it’s passed unless it’s going to
+ * succeed. In particular, if a method call is not optimisable, it must not
+ * modify the stack it’s passed.
+ *
  * You need to add a custom function using xb_machine_add_method() before using
  * methods that may reference it, for example xb_machine_add_opcode_fixup().
  *
@@ -220,6 +224,32 @@ xb_machine_find_func (XbMachine *self, const gchar *func_name)
 }
 
 /**
+ * xb_machine_opcode_func_init:
+ * @self: a #XbMachine
+ * @opcode: (out caller-allocates): a stack allocated #XbOpcode to initialise
+ * @func_name: function name, e.g. `eq`
+ *
+ * Initialises a stack allocated #XbOpcode for a registered function.
+ * Some standard functions are registered by default, for instance `eq` or `ge`.
+ * Other functions have to be added using xb_machine_add_method().
+ *
+ * Returns: %TRUE if the function was found and the opcode initialised, %FALSE
+ *    otherwise
+ * Since: 0.2.0
+ **/
+gboolean
+xb_machine_opcode_func_init (XbMachine *self, XbOpcode *opcode, const gchar *func_name)
+{
+	XbMachineMethodItem *item = xb_machine_find_func (self, func_name);
+	if (item == NULL)
+		return FALSE;
+	xb_opcode_init (opcode, XB_OPCODE_KIND_FUNCTION,
+			g_strdup (func_name),
+			item->idx, g_free);
+	return TRUE;
+}
+
+/**
  * xb_machine_opcode_func_new:
  * @self: a #XbMachine
  * @func_name: function name, e.g. `eq`
@@ -231,16 +261,12 @@ xb_machine_find_func (XbMachine *self, const gchar *func_name)
  * Returns: a new #XbOpcode, or %NULL
  *
  * Since: 0.1.1
+ * Deprecated: 0.2.0: Use xb_machine_opcode_func_init() instead
  **/
 XbOpcode *
 xb_machine_opcode_func_new (XbMachine *self, const gchar *func_name)
 {
-	XbMachineMethodItem *item = xb_machine_find_func (self, func_name);
-	if (item == NULL)
-		return NULL;
-	return xb_opcode_new (XB_OPCODE_KIND_FUNCTION,
-			      g_strdup (func_name),
-			      item->idx, g_free);
+	g_assert_not_reached ();
 }
 
 static gboolean
@@ -250,23 +276,24 @@ xb_machine_parse_add_func (XbMachine *self,
 			   GError **error)
 {
 	XbMachinePrivate *priv = GET_PRIVATE (self);
-	g_autoptr(XbOpcode) opcode = NULL;
+	XbOpcode *opcode;
 
-	/* match opcode, which should always exist */
-	opcode = xb_machine_opcode_func_new (self, func_name);
-	if (opcode == NULL) {
-		g_set_error (error,
-			     G_IO_ERROR,
-			     G_IO_ERROR_NOT_SUPPORTED,
-			     "built-in function not found: %s", func_name);
-		return FALSE;
-	}
-	if (!xb_stack_push_steal (opcodes, g_steal_pointer (&opcode))) {
+	if (!xb_stack_push (opcodes, &opcode)) {
 		g_set_error (error,
 			     G_IO_ERROR,
 			     G_IO_ERROR_NOT_SUPPORTED,
 			     "stack size %u exhausted",
 			     priv->stack_size);
+		return FALSE;
+	}
+
+	/* match opcode, which should always exist */
+	if (!xb_machine_opcode_func_init (self, opcode, func_name)) {
+		g_set_error (error,
+			     G_IO_ERROR,
+			     G_IO_ERROR_NOT_SUPPORTED,
+			     "built-in function not found: %s", func_name);
+		xb_stack_pop (opcodes, NULL);
 		return FALSE;
 	}
 
@@ -352,7 +379,10 @@ xb_machine_parse_add_text (XbMachine *self,
 
 	/* NULL is perfectly valid */
 	if (text == NULL) {
-		xb_stack_push_steal (opcodes, xb_opcode_text_new_static (str));
+		XbOpcode *opcode;
+		if (!xb_stack_push (opcodes, &opcode))
+			return FALSE;
+		xb_opcode_text_init_static (opcode, str);
 		return TRUE;
 	}
 
@@ -376,8 +406,11 @@ xb_machine_parse_add_text (XbMachine *self,
 	/* quoted text */
 	if (text_len >= 2) {
 		if (str[0] == '\'' && str[text_len - 1] == '\'') {
-			gchar *tmp = g_strndup (str + 1, text_len - 2);
-			xb_stack_push_steal (opcodes, xb_opcode_text_new_steal (tmp));
+			g_autofree gchar *tmp = g_strndup (str + 1, text_len - 2);
+			XbOpcode *opcode;
+			if (!xb_stack_push (opcodes, &opcode))
+				return FALSE;
+			xb_opcode_text_init_steal (opcode, g_steal_pointer (&tmp));
 			return TRUE;
 		}
 	}
@@ -386,22 +419,29 @@ xb_machine_parse_add_text (XbMachine *self,
 	if (text_len >= 3) {
 		if (str[0] == '$' && str[1] == '\'' && str[text_len - 1] == '\'') {
 			gchar *tmp = g_strndup (str + 2, text_len - 3);
-			XbOpcode *op = xb_opcode_new (XB_OPCODE_KIND_INDEXED_TEXT,
-						      tmp, XB_SILO_UNSET, g_free);
-			xb_stack_push_steal (opcodes, op);
+			XbOpcode *opcode;
+			if (!xb_stack_push (opcodes, &opcode))
+				return FALSE;
+			xb_opcode_init (opcode, XB_OPCODE_KIND_INDEXED_TEXT, tmp, XB_SILO_UNSET, g_free);
 			return TRUE;
 		}
 	}
 
 	/* bind variables */
 	if (g_strcmp0 (str, "?") == 0) {
-		xb_stack_push_steal (opcodes, xb_opcode_bind_new ());
+		XbOpcode *opcode;
+		if (!xb_stack_push (opcodes, &opcode))
+			return FALSE;
+		xb_opcode_bind_init (opcode);
 		return TRUE;
 	}
 
 	/* check for plain integer */
 	if (g_ascii_string_to_unsigned (str, 10, 0, G_MAXUINT32, &val, NULL)) {
-		xb_stack_push_steal (opcodes, xb_opcode_integer_new (val));
+		XbOpcode *opcode;
+		if (!xb_stack_push (opcodes, &opcode))
+			return FALSE;
+		xb_opcode_integer_init (opcode, val);
 		return TRUE;
 	}
 
@@ -535,30 +575,35 @@ xb_machine_get_opcodes_sig (XbMachine *self, XbStack *opcodes)
 	return g_string_free (str, FALSE);
 }
 
+/* @results *must* have enough space
+ * @op is transfer full into this function */
 static gboolean
 xb_machine_opcodes_optimize_fn (XbMachine *self,
-				XbOpcode *op,
-				guint *idx,
-				GPtrArray *src,
-				GPtrArray *dst,
+				XbStack *opcodes,
+				XbOpcode op,
+				XbStack *results,
 				GError **error)
 {
 	XbMachineMethodItem *item;
 	XbMachinePrivate *priv = GET_PRIVATE (self);
 	g_autofree gchar *stack_str = NULL;
 	g_autoptr(GError) error_local = NULL;
-	g_autoptr(XbOpcode) op_result = NULL;
-	g_autoptr(XbStack) stack = NULL;
+	g_auto(XbOpcode) op_result = XB_OPCODE_INIT ();
+	g_auto(XbOpcode) op_owned = op;
 
 	/* a function! lets check the arg length */
-	if (xb_opcode_get_kind (op) != XB_OPCODE_KIND_FUNCTION) {
-		g_ptr_array_add (dst, xb_opcode_ref (op));
+	if (xb_opcode_get_kind (&op) != XB_OPCODE_KIND_FUNCTION) {
+		XbOpcode *op_out;
+		gboolean pushed;
+		pushed = xb_stack_push (results, &op_out);
+		g_assert (pushed);
+		*op_out = xb_opcode_steal (&op_owned);
 		return TRUE;
 	}
 
 	/* get function, check if we have enough arguments */
-	item = g_ptr_array_index (priv->methods, xb_opcode_get_val (op));
-	if (item->n_opcodes >= *idx) {
+	item = g_ptr_array_index (priv->methods, xb_opcode_get_val (&op));
+	if (item->n_opcodes > xb_stack_get_size (opcodes)) {
 		g_set_error_literal (error,
 				     G_IO_ERROR,
 				     G_IO_ERROR_INVALID_DATA,
@@ -566,52 +611,48 @@ xb_machine_opcodes_optimize_fn (XbMachine *self,
 		return FALSE;
 	}
 
-	/* make a copy of the stack with the arguments */
-	stack = xb_stack_new (item->n_opcodes);
-	for (guint i = item->n_opcodes; i > 0; i--) {
-		XbOpcode *op_tmp = g_ptr_array_index (src, *idx - (i + 1));
-		xb_stack_push (stack, op_tmp);
-	}
+	/* run the method. it's only supposed to pop its arguments off the stack
+	 * if it can complete successfully */
+	stack_str = xb_stack_to_string (opcodes);
+	if (!item->method_cb (self, opcodes, NULL, item->user_data, NULL, &error_local)) {
+		XbOpcode *op_out;
+		gboolean pushed;
 
-	/* run the method */
-	stack_str = xb_stack_to_string (stack);
-	if (!item->method_cb (self, stack, NULL, item->user_data, NULL, &error_local)) {
 		if (priv->debug_flags & XB_MACHINE_DEBUG_FLAG_SHOW_OPTIMIZER) {
 			g_debug ("ignoring optimized call to %s(%s): %s",
 				 item->name,
 				 stack_str,
 				 error_local->message);
 		}
-		g_ptr_array_add (dst, xb_opcode_ref (op));
+
+		pushed = xb_stack_push (results, &op_out);
+		g_assert (pushed);
+		*op_out = xb_opcode_steal (&op_owned);
 		return TRUE;
 	}
 
-	/* the method ran, add the result and discard the arguments */
-	op_result = xb_stack_pop (stack);
-	if (op_result == NULL) {
+	/* the method ran, add the result. the arguments have already been popped */
+	if (!xb_machine_stack_pop (self, opcodes, &op_result)) {
 		g_set_error_literal (error,
 				     G_IO_ERROR,
 				     G_IO_ERROR_INVALID_DATA,
 				     "internal error; no retval on stack");
 		return FALSE;
 	}
-	if (xb_opcode_get_kind (op_result) != XB_OPCODE_KIND_BOOLEAN) {
-		if (priv->debug_flags & XB_MACHINE_DEBUG_FLAG_SHOW_OPTIMIZER)
-			g_debug ("method ran, adding result");
-		*idx -= item->n_opcodes;
-		g_ptr_array_add (dst, g_steal_pointer (&op_result));
-		return TRUE;
-	}
+	if (xb_opcode_get_kind (&op_result) != XB_OPCODE_KIND_BOOLEAN ||
+	    xb_opcode_get_val (&op_result)) {
+		XbOpcode *op_out;
+		gboolean pushed;
 
-	/* nothing was added to the stack, so check if the predicate will
-	 * always evaluate to TRUE */
-	if (priv->debug_flags & XB_MACHINE_DEBUG_FLAG_SHOW_OPTIMIZER) {
-		g_autofree gchar *tmp = xb_opcode_to_string (op_result);
-		g_debug ("method ran, result %s", tmp);
-	}
-	if (xb_opcode_get_val (op_result) == TRUE) {
-		*idx -= item->n_opcodes;
-		g_ptr_array_add (dst, g_steal_pointer (&op_result));
+		if (priv->debug_flags & XB_MACHINE_DEBUG_FLAG_SHOW_OPTIMIZER) {
+			g_autofree gchar *tmp = xb_opcode_to_string (&op_result);
+			g_debug ("method ran, adding result %s", tmp);
+		}
+
+		pushed = xb_stack_push (results, &op_out);
+		g_assert (pushed);
+		*op_out = xb_opcode_steal (&op_result);
+
 		return TRUE;
 	}
 
@@ -628,8 +669,8 @@ static gboolean
 xb_machine_opcodes_optimize (XbMachine *self, XbStack *opcodes, GError **error)
 {
 	XbMachinePrivate *priv = GET_PRIVATE (self);
-	g_autoptr(GPtrArray) dst = NULL;
-	g_autoptr(GPtrArray) src = NULL;
+	g_autoptr(XbStack) results = xb_stack_new (xb_stack_get_size (opcodes));
+	g_auto(XbOpcode) op = XB_OPCODE_INIT ();
 
 	/* debug */
 	if (priv->debug_flags & XB_MACHINE_DEBUG_FLAG_SHOW_STACK) {
@@ -638,18 +679,19 @@ xb_machine_opcodes_optimize (XbMachine *self, XbStack *opcodes, GError **error)
 	}
 
 	/* process the stack in reverse order */
-	src = xb_stack_steal_all (opcodes);
-	dst = xb_stack_steal_all (opcodes);
-	for (guint i = src->len; i > 0; i--) {
-		XbOpcode *op = g_ptr_array_index (src, i - 1);
-		if (!xb_machine_opcodes_optimize_fn (self, op, &i, src, dst, error))
+	while (xb_machine_stack_pop (self, opcodes, &op)) {
+		/* this takes ownership of @op */
+		if (!xb_machine_opcodes_optimize_fn (self, opcodes, xb_opcode_steal (&op), results, error))
 			return FALSE;
 	}
 
-	/* copy back the result into the opcodes stack */
-	for (guint i = dst->len; i > 0; i--) {
-		XbOpcode *op = g_ptr_array_index (dst, i - 1);
-		xb_stack_push (opcodes, op);
+	/* copy back the result into the opcodes stack (and reverse it) */
+	while (xb_stack_pop (results, &op)) {
+		XbOpcode *op_out;
+		gboolean pushed;
+		pushed = xb_stack_push (opcodes, &op_out);
+		g_assert (pushed);
+		*op_out = xb_opcode_steal (&op);
 	}
 
 	/* debug */
@@ -797,6 +839,11 @@ xb_machine_parse_full (XbMachine *self,
 	if (flags & XB_MACHINE_PARSE_FLAG_OPTIMIZE) {
 		for (guint i = 0; i < 10; i++) {
 			guint oldsz = xb_stack_get_size (opcodes);
+
+			/* Is the stack optimal already? */
+			if (oldsz == 1)
+				break;
+
 			if (!xb_machine_opcodes_optimize (self, opcodes, error))
 				return NULL;
 			if (oldsz == xb_stack_get_size (opcodes))
@@ -938,8 +985,9 @@ xb_machine_run (XbMachine *self,
 		GError **error)
 {
 	XbMachinePrivate *priv = GET_PRIVATE (self);
-	g_autoptr(XbOpcode) opcode_success = NULL;
+	g_auto(XbOpcode) opcode_success = XB_OPCODE_INIT ();
 	g_autoptr(XbStack) stack = NULL;
+	guint opcodes_stack_size = xb_stack_get_size (opcodes);
 
 	g_return_val_if_fail (XB_IS_MACHINE (self), FALSE);
 	g_return_val_if_fail (opcodes != NULL, FALSE);
@@ -948,7 +996,7 @@ xb_machine_run (XbMachine *self,
 
 	/* process each opcode */
 	stack = xb_stack_new (priv->stack_size);
-	for (guint i = 0; i < xb_stack_get_size (opcodes); i++) {
+	for (guint i = 0; i < opcodes_stack_size; i++) {
 		XbOpcode *opcode = xb_stack_peek (opcodes, i);
 		XbOpcodeKind kind = xb_opcode_get_kind (opcode);
 
@@ -963,14 +1011,20 @@ xb_machine_run (XbMachine *self,
 			continue;
 		}
 
-		/* add to stack */
+		/* add to stack; this uses a const copy of the input opcode,
+		 * so ownership of anything allocated on the heap remains with
+		 * the caller */
 		if (kind == XB_OPCODE_KIND_TEXT ||
 		    kind == XB_OPCODE_KIND_BOOLEAN ||
 		    kind == XB_OPCODE_KIND_INTEGER ||
 		    kind == XB_OPCODE_KIND_INDEXED_TEXT ||
 		    kind == XB_OPCODE_KIND_BOUND_TEXT ||
 		    kind == XB_OPCODE_KIND_BOUND_INTEGER) {
-			xb_machine_stack_push (self, stack, opcode);
+			XbOpcode *machine_opcode;
+			if (!xb_machine_stack_push (self, stack, &machine_opcode, error))
+				return FALSE;
+			*machine_opcode = *opcode;
+			machine_opcode->destroy_func = NULL;
 			continue;
 		}
 
@@ -1005,8 +1059,8 @@ xb_machine_run (XbMachine *self,
 			     xb_stack_get_size (stack), tmp);
 		return FALSE;
 	}
-	opcode_success = xb_stack_pop (stack);
-	if (xb_opcode_get_kind (opcode_success) != XB_OPCODE_KIND_BOOLEAN) {
+	xb_stack_pop (stack, &opcode_success);
+	if (xb_opcode_get_kind (&opcode_success) != XB_OPCODE_KIND_BOOLEAN) {
 		g_autofree gchar *tmp = xb_stack_to_string (stack);
 		g_set_error (error,
 			     G_IO_ERROR,
@@ -1015,7 +1069,7 @@ xb_machine_run (XbMachine *self,
 		return FALSE;
 	}
 	if (result != NULL)
-		*result = xb_opcode_get_val (opcode_success);
+		*result = xb_opcode_get_val (&opcode_success);
 
 	/* success */
 	return TRUE;
@@ -1025,47 +1079,70 @@ xb_machine_run (XbMachine *self,
  * xb_machine_stack_pop:
  * @self: a #XbMachine
  * @stack: a #XbStack
+ * @opcode_out: (out caller-allocates) (optional): return location for the popped #XbOpcode
  *
  * Pops an opcode from the stack.
  *
- * Returns: (transfer full): a new #XbOpcode, or %NULL
+ * Returns: %TRUE if popping succeeded, %FALSE if the stack was empty already
  *
- * Since: 0.1.1
+ * Since: 0.2.0
  **/
-XbOpcode *
-xb_machine_stack_pop (XbMachine *self, XbStack *stack)
+gboolean
+xb_machine_stack_pop (XbMachine *self, XbStack *stack, XbOpcode *opcode_out)
 {
 	XbMachinePrivate *priv = GET_PRIVATE (self);
+	gboolean retval;
+
 	if (priv->debug_flags & XB_MACHINE_DEBUG_FLAG_SHOW_STACK) {
-		XbOpcode *opcode = xb_stack_peek (stack, xb_stack_get_size (stack) - 1);
-		g_autofree gchar *str = xb_opcode_to_string (opcode);
-		g_debug ("popping: %s", str);
-		xb_machine_debug_show_stack (self, stack);
+		XbOpcode *opcode_peek = xb_stack_peek (stack, xb_stack_get_size (stack) - 1);
+		if (opcode_peek != NULL) {
+			g_autofree gchar *str = xb_opcode_to_string (opcode_peek);
+			g_debug ("popping: %s", str);
+		} else {
+			g_debug ("not popping: stack empty");
+		}
 	}
-	return xb_stack_pop (stack);
+
+	retval = xb_stack_pop (stack, opcode_out);
+
+	if (priv->debug_flags & XB_MACHINE_DEBUG_FLAG_SHOW_STACK)
+		xb_machine_debug_show_stack (self, stack);
+
+	return retval;
 }
 
 /**
  * xb_machine_stack_push:
  * @self: a #XbMachine
  * @stack: a #XbStack
- * @opcode: a #XbOpcode
+ * @opcode_out: (out) (nullable): return location for the new #XbOpcode
+ * @error: return location for a #GError, or %NULL
  *
- * Adds an opcode to the stack.
+ * Pushes a new empty opcode onto the end of the stack. A pointer to the opcode
+ * is returned in @opcode_out so that the caller can initialise it.
  *
- * Since: 0.1.1
+ * If the stack reaches its maximum size, %G_IO_ERROR_NO_SPACE will be returned.
+ *
+ * Returns: %TRUE if a new empty opcode was returned, or %FALSE if the stack has
+ *    reached its maximum size
+ * Since: 0.2.0
  **/
-void
-xb_machine_stack_push (XbMachine *self, XbStack *stack, XbOpcode *opcode)
+gboolean
+xb_machine_stack_push (XbMachine *self, XbStack *stack, XbOpcode **opcode_out, GError **error)
 {
 	XbMachinePrivate *priv = GET_PRIVATE (self);
+
 	if (priv->debug_flags & XB_MACHINE_DEBUG_FLAG_SHOW_STACK) {
-		g_autofree gchar *str = xb_opcode_to_string (opcode);
-		g_debug ("pushing: %s", str);
+		g_debug ("pushing generic opcode");
 	}
-	xb_stack_push (stack, opcode);
-	if (priv->debug_flags & XB_MACHINE_DEBUG_FLAG_SHOW_STACK)
-		xb_machine_debug_show_stack (self, stack);
+
+	if (!xb_stack_push (stack, opcode_out)) {
+		g_set_error_literal (error, G_IO_ERROR, G_IO_ERROR_NO_SPACE,
+				     "machine maximum stack size reached");
+		return FALSE;
+	}
+
+	return TRUE;
 }
 
 /**
@@ -1077,18 +1154,12 @@ xb_machine_stack_push (XbMachine *self, XbStack *stack, XbOpcode *opcode)
  * Adds an stolen opcode to the stack.
  *
  * Since: 0.1.4
+ * Deprecated: 0.2.0: Use xb_machine_stack_push() instead
  **/
 void
 xb_machine_stack_push_steal (XbMachine *self, XbStack *stack, XbOpcode *opcode)
 {
-	XbMachinePrivate *priv = GET_PRIVATE (self);
-	if (priv->debug_flags & XB_MACHINE_DEBUG_FLAG_SHOW_STACK) {
-		g_autofree gchar *str = xb_opcode_to_string (opcode);
-		g_debug ("pushing: %s", str);
-	}
-	xb_stack_push_steal (stack, opcode);
-	if (priv->debug_flags & XB_MACHINE_DEBUG_FLAG_SHOW_STACK)
-		xb_machine_debug_show_stack (self, stack);
+	g_assert_not_reached ();
 }
 
 /**
@@ -1096,20 +1167,35 @@ xb_machine_stack_push_steal (XbMachine *self, XbStack *stack, XbOpcode *opcode)
  * @self: a #XbMachine
  * @stack: a #XbStack
  * @str: text literal
+ * @error: return location for a #GError, or %NULL
  *
  * Adds a text literal to the stack, copying @str.
  *
- * Since: 0.1.1
+ * Errors are as for xb_machine_stack_push().
+ *
+ * Returns: %TRUE on success, %FALSE otherwise
+ * Since: 0.2.0
  **/
-void
-xb_machine_stack_push_text (XbMachine *self, XbStack *stack, const gchar *str)
+gboolean
+xb_machine_stack_push_text (XbMachine *self, XbStack *stack, const gchar *str, GError **error)
 {
 	XbMachinePrivate *priv = GET_PRIVATE (self);
+	XbOpcode *opcode;
+
 	if (priv->debug_flags & XB_MACHINE_DEBUG_FLAG_SHOW_STACK)
 		g_debug ("pushing: %s", str);
-	xb_stack_push_steal (stack, xb_opcode_text_new (str));
+
+	if (!xb_stack_push (stack, &opcode)) {
+		g_set_error_literal (error, G_IO_ERROR, G_IO_ERROR_NO_SPACE,
+				     "machine maximum stack size reached");
+		return FALSE;
+	}
+
+	xb_opcode_text_init (opcode, str);
 	if (priv->debug_flags & XB_MACHINE_DEBUG_FLAG_SHOW_STACK)
 		xb_machine_debug_show_stack (self, stack);
+
+	return TRUE;
 }
 
 /**
@@ -1117,41 +1203,72 @@ xb_machine_stack_push_text (XbMachine *self, XbStack *stack, const gchar *str)
  * @self: a #XbMachine
  * @stack: a #XbStack
  * @str: text literal
+ * @error: return location for a #GError, or %NULL
  *
  * Adds static text literal to the stack.
  *
- * Since: 0.1.1
+ * Errors are as for xb_machine_stack_push().
+ *
+ * Returns: %TRUE on success, %FALSE otherwise
+ * Since: 0.2.0
  **/
-void
-xb_machine_stack_push_text_static (XbMachine *self, XbStack *stack, const gchar *str)
+gboolean
+xb_machine_stack_push_text_static (XbMachine *self, XbStack *stack, const gchar *str, GError **error)
 {
+	XbOpcode *opcode;
+
 	XbMachinePrivate *priv = GET_PRIVATE (self);
 	if (priv->debug_flags & XB_MACHINE_DEBUG_FLAG_SHOW_STACK)
 		g_debug ("pushing: %s", str);
-	xb_stack_push_steal (stack, xb_opcode_text_new_static (str));
+
+	if (!xb_stack_push (stack, &opcode)) {
+		g_set_error_literal (error, G_IO_ERROR, G_IO_ERROR_NO_SPACE,
+				     "machine maximum stack size reached");
+		return FALSE;
+	}
+
+	xb_opcode_text_init_static (opcode, str);
 	if (priv->debug_flags & XB_MACHINE_DEBUG_FLAG_SHOW_STACK)
 		xb_machine_debug_show_stack (self, stack);
+
+	return TRUE;
 }
 
 /**
  * xb_machine_stack_push_text_steal:
  * @self: a #XbMachine
  * @stack: a #XbStack
- * @str: text literal
+ * @str: (transfer full): text literal
+ * @error: return location for a #GError, or %NULL
  *
  * Adds a stolen text literal to the stack.
  *
- * Since: 0.1.1
+ * Errors are as for xb_machine_stack_push().
+ *
+ * Returns: %TRUE on success, %FALSE otherwise
+ * Since: 0.2.0
  **/
-void
-xb_machine_stack_push_text_steal (XbMachine *self, XbStack *stack, gchar *str)
+gboolean
+xb_machine_stack_push_text_steal (XbMachine *self, XbStack *stack, gchar *str, GError **error)
 {
 	XbMachinePrivate *priv = GET_PRIVATE (self);
+	XbOpcode *opcode;
+	g_autofree gchar *str_stolen = g_steal_pointer (&str);
+
 	if (priv->debug_flags & XB_MACHINE_DEBUG_FLAG_SHOW_STACK)
-		g_debug ("pushing: %s", str);
-	xb_stack_push_steal (stack, xb_opcode_text_new_steal (str));
+		g_debug ("pushing: %s", str_stolen);
+
+	if (!xb_stack_push (stack, &opcode)) {
+		g_set_error_literal (error, G_IO_ERROR, G_IO_ERROR_NO_SPACE,
+				     "machine maximum stack size reached");
+		return FALSE;
+	}
+
+	xb_opcode_text_init_steal (opcode, g_steal_pointer (&str_stolen));
 	if (priv->debug_flags & XB_MACHINE_DEBUG_FLAG_SHOW_STACK)
 		xb_machine_debug_show_stack (self, stack);
+
+	return TRUE;
 }
 
 /**
@@ -1159,20 +1276,35 @@ xb_machine_stack_push_text_steal (XbMachine *self, XbStack *stack, gchar *str)
  * @self: a #XbMachine
  * @stack: a #XbStack
  * @val: integer literal
+ * @error: return location for a #GError, or %NULL
  *
  * Adds an integer literal to the stack.
  *
- * Since: 0.1.1
+ * Errors are as for xb_machine_stack_push().
+ *
+ * Returns: %TRUE on success, %FALSE otherwise
+ * Since: 0.2.0
  **/
-void
-xb_machine_stack_push_integer (XbMachine *self, XbStack *stack, guint32 val)
+gboolean
+xb_machine_stack_push_integer (XbMachine *self, XbStack *stack, guint32 val, GError **error)
 {
 	XbMachinePrivate *priv = GET_PRIVATE (self);
+	XbOpcode *opcode;
+
 	if (priv->debug_flags & XB_MACHINE_DEBUG_FLAG_SHOW_STACK)
 		g_debug ("pushing: %u", val);
-	xb_stack_push_steal (stack, xb_opcode_integer_new (val));
+
+	if (!xb_stack_push (stack, &opcode)) {
+		g_set_error_literal (error, G_IO_ERROR, G_IO_ERROR_NO_SPACE,
+				     "machine maximum stack size reached");
+		return FALSE;
+	}
+
+	xb_opcode_integer_init (opcode, val);
 	if (priv->debug_flags & XB_MACHINE_DEBUG_FLAG_SHOW_STACK)
 		xb_machine_debug_show_stack (self, stack);
+
+	return TRUE;
 }
 
 /**
@@ -1214,6 +1346,61 @@ xb_machine_get_stack_size (XbMachine *self)
 	return priv->stack_size;
 }
 
+typedef gboolean (*OpcodeCheckFunc) (XbOpcode *op);
+
+static gboolean
+opcode_cmp_val_or_str (XbOpcode *op)
+{
+	return (xb_opcode_cmp_str (op) || xb_opcode_cmp_val (op));
+}
+
+static gboolean
+check_one_arg (XbStack *stack,
+	       OpcodeCheckFunc f,
+	       GError **error)
+{
+	XbOpcode *head;
+
+	head = xb_stack_peek_tail (stack);
+	if (head == NULL || !f (head)) {
+		g_set_error (error,
+			     G_IO_ERROR,
+			     G_IO_ERROR_NOT_SUPPORTED,
+			     "%s type not supported",
+			     (head != NULL) ? xb_opcode_kind_to_string (xb_opcode_get_kind (head)) : "(null)");
+		return FALSE;
+	}
+
+	return TRUE;
+}
+
+static gboolean
+check_two_args (XbStack *stack,
+		OpcodeCheckFunc f1,
+		OpcodeCheckFunc f2,
+		GError **error)
+{
+	XbOpcode *head1 = NULL, *head2 = NULL;
+	guint stack_size = xb_stack_get_size (stack);
+
+	if (stack_size >= 2) {
+		head1 = xb_stack_peek (stack, stack_size - 1);
+		head2 = xb_stack_peek (stack, stack_size - 2);
+	}
+	if (head1 == NULL || head2 == NULL ||
+	    !f1 (head1) || !f2 (head2)) {
+		g_set_error (error,
+			     G_IO_ERROR,
+			     G_IO_ERROR_NOT_SUPPORTED,
+			     "%s:%s types not supported",
+			     (head1 != NULL) ? xb_opcode_kind_to_string (xb_opcode_get_kind (head1)) : "(null)",
+			     (head2 != NULL) ? xb_opcode_kind_to_string (xb_opcode_get_kind (head2)) : "(null)");
+		return FALSE;
+	}
+
+	return TRUE;
+}
+
 static gboolean
 xb_machine_func_and_cb (XbMachine *self,
 			XbStack *stack,
@@ -1222,23 +1409,17 @@ xb_machine_func_and_cb (XbMachine *self,
 			gpointer exec_data,
 			GError **error)
 {
-	g_autoptr(XbOpcode) op1 = xb_machine_stack_pop (self, stack);
-	g_autoptr(XbOpcode) op2 = xb_machine_stack_pop (self, stack);
+	g_auto(XbOpcode) op1 = XB_OPCODE_INIT (), op2 = XB_OPCODE_INIT ();
+
+	if (!check_two_args (stack, xb_opcode_cmp_val, xb_opcode_cmp_val, error))
+		return FALSE;
+
+	xb_machine_stack_pop (self, stack, &op1);
+	xb_machine_stack_pop (self, stack, &op2);
 
 	/* INTE:INTE */
-	if (xb_opcode_cmp_val (op1) && xb_opcode_cmp_val (op2)) {
-		xb_stack_push_bool (stack, xb_opcode_get_val (op1) && xb_opcode_get_val (op2));
-		return TRUE;
-	}
-
-	/* fail */
-	g_set_error (error,
-		     G_IO_ERROR,
-		     G_IO_ERROR_NOT_SUPPORTED,
-		     "%s:%s types not supported",
-		     xb_opcode_kind_to_string (xb_opcode_get_kind (op1)),
-		     xb_opcode_kind_to_string (xb_opcode_get_kind (op2)));
-	return FALSE;
+	xb_stack_push_bool (stack, xb_opcode_get_val (&op1) && xb_opcode_get_val (&op2));
+	return TRUE;
 }
 
 static gboolean
@@ -1249,23 +1430,17 @@ xb_machine_func_or_cb (XbMachine *self,
 		       gpointer exec_data,
 		       GError **error)
 {
-	g_autoptr(XbOpcode) op1 = xb_machine_stack_pop (self, stack);
-	g_autoptr(XbOpcode) op2 = xb_machine_stack_pop (self, stack);
+	g_auto(XbOpcode) op1 = XB_OPCODE_INIT (), op2 = XB_OPCODE_INIT ();
+
+	if (!check_two_args (stack, xb_opcode_cmp_val, xb_opcode_cmp_val, error))
+		return FALSE;
+
+	xb_machine_stack_pop (self, stack, &op1);
+	xb_machine_stack_pop (self, stack, &op2);
 
 	/* INTE:INTE */
-	if (xb_opcode_cmp_val (op1) && xb_opcode_cmp_val (op2)) {
-		xb_stack_push_bool (stack, xb_opcode_get_val (op1) || xb_opcode_get_val (op2));
-		return TRUE;
-	}
-
-	/* fail */
-	g_set_error (error,
-		     G_IO_ERROR,
-		     G_IO_ERROR_NOT_SUPPORTED,
-		     "%s:%s types not supported",
-		     xb_opcode_kind_to_string (xb_opcode_get_kind (op1)),
-		     xb_opcode_kind_to_string (xb_opcode_get_kind (op2)));
-	return FALSE;
+	xb_stack_push_bool (stack, xb_opcode_get_val (&op1) || xb_opcode_get_val (&op2));
+	return TRUE;
 }
 
 static gboolean
@@ -1276,62 +1451,61 @@ xb_machine_func_eq_cb (XbMachine *self,
 		       gpointer exec_data,
 		       GError **error)
 {
-	g_autoptr(XbOpcode) op1 = xb_machine_stack_pop (self, stack);
-	g_autoptr(XbOpcode) op2 = xb_machine_stack_pop (self, stack);
+	g_auto(XbOpcode) op1 = XB_OPCODE_INIT (), op2 = XB_OPCODE_INIT ();
+
+	if (!check_two_args (stack, opcode_cmp_val_or_str, opcode_cmp_val_or_str, error))
+		return FALSE;
+
+	xb_machine_stack_pop (self, stack, &op1);
+	xb_machine_stack_pop (self, stack, &op2);
 
 	/* INTE:INTE */
-	if (xb_opcode_cmp_val (op1) && xb_opcode_cmp_val (op2)) {
-		xb_stack_push_bool (stack, xb_opcode_get_val (op1) == xb_opcode_get_val (op2));
+	if (xb_opcode_cmp_val (&op1) && xb_opcode_cmp_val (&op2)) {
+		xb_stack_push_bool (stack, xb_opcode_get_val (&op1) == xb_opcode_get_val (&op2));
 		return TRUE;
 	}
 
 	/* TEXT:TEXT */
-	if (xb_opcode_cmp_str (op1) && xb_opcode_cmp_str (op2)) {
-		xb_stack_push_bool (stack, g_strcmp0 (xb_opcode_get_str (op1),
-						      xb_opcode_get_str (op2)) == 0);
+	if (xb_opcode_cmp_str (&op1) && xb_opcode_cmp_str (&op2)) {
+		xb_stack_push_bool (stack, g_strcmp0 (xb_opcode_get_str (&op1),
+						      xb_opcode_get_str (&op2)) == 0);
 		return TRUE;
 	}
 
 	/* INTE:TEXT */
-	if (xb_opcode_cmp_val (op1) && xb_opcode_cmp_str (op2)) {
+	if (xb_opcode_cmp_val (&op1) && xb_opcode_cmp_str (&op2)) {
 		guint64 val = 0;
-		if (xb_opcode_get_str (op2) == NULL) {
+		if (xb_opcode_get_str (&op2) == NULL) {
 			xb_stack_push_bool (stack, FALSE);
 			return TRUE;
 		}
-		if (!g_ascii_string_to_unsigned (xb_opcode_get_str (op2),
+		if (!g_ascii_string_to_unsigned (xb_opcode_get_str (&op2),
 						 10, 0, G_MAXUINT32,
 						 &val, error)) {
 			return FALSE;
 		}
-		xb_stack_push_bool (stack, val == xb_opcode_get_val (op1));
+		xb_stack_push_bool (stack, val == xb_opcode_get_val (&op1));
 		return TRUE;
 	}
 
 	/* INTE:TEXT */
-	if (xb_opcode_cmp_val (op2) && xb_opcode_cmp_str (op1)) {
+	if (xb_opcode_cmp_val (&op2) && xb_opcode_cmp_str (&op1)) {
 		guint64 val = 0;
-		if (xb_opcode_get_str (op1) == NULL) {
+		if (xb_opcode_get_str (&op1) == NULL) {
 			xb_stack_push_bool (stack, FALSE);
 			return TRUE;
 		}
-		if (!g_ascii_string_to_unsigned (xb_opcode_get_str (op1),
+		if (!g_ascii_string_to_unsigned (xb_opcode_get_str (&op1),
 						 10, 0, G_MAXUINT32,
 						 &val, error)) {
 			return FALSE;
 		}
-		xb_stack_push_bool (stack, val == xb_opcode_get_val (op2));
+		xb_stack_push_bool (stack, val == xb_opcode_get_val (&op2));
 		return TRUE;
 	}
 
-	/* fail */
-	g_set_error (error,
-		     G_IO_ERROR,
-		     G_IO_ERROR_NOT_SUPPORTED,
-		     "%s:%s types not supported",
-		     xb_opcode_kind_to_string (xb_opcode_get_kind (op1)),
-		     xb_opcode_kind_to_string (xb_opcode_get_kind (op2)));
-	return FALSE;
+	/* Should have been checked above. */
+	g_assert_not_reached ();
 }
 
 static gboolean
@@ -1342,46 +1516,45 @@ xb_machine_func_ne_cb (XbMachine *self,
 		       gpointer exec_data,
 		       GError **error)
 {
-	g_autoptr(XbOpcode) op1 = xb_machine_stack_pop (self, stack);
-	g_autoptr(XbOpcode) op2 = xb_machine_stack_pop (self, stack);
+	g_auto(XbOpcode) op1 = XB_OPCODE_INIT (), op2 = XB_OPCODE_INIT ();
+
+	if (!check_two_args (stack, opcode_cmp_val_or_str, opcode_cmp_val_or_str, error))
+		return FALSE;
+
+	xb_machine_stack_pop (self, stack, &op1);
+	xb_machine_stack_pop (self, stack, &op2);
 
 	/* INTE:INTE */
-	if (xb_opcode_cmp_val (op1) && xb_opcode_cmp_val (op2)) {
-		xb_stack_push_bool (stack, xb_opcode_get_val (op1) != xb_opcode_get_val (op2));
+	if (xb_opcode_cmp_val (&op1) && xb_opcode_cmp_val (&op2)) {
+		xb_stack_push_bool (stack, xb_opcode_get_val (&op1) != xb_opcode_get_val (&op2));
 		return TRUE;
 	}
 
 	/* TEXT:TEXT */
-	if (xb_opcode_cmp_str (op1) && xb_opcode_cmp_str (op2)) {
-		xb_stack_push_bool (stack, g_strcmp0 (xb_opcode_get_str (op1),
-						      xb_opcode_get_str (op2)) != 0);
+	if (xb_opcode_cmp_str (&op1) && xb_opcode_cmp_str (&op2)) {
+		xb_stack_push_bool (stack, g_strcmp0 (xb_opcode_get_str (&op1),
+						      xb_opcode_get_str (&op2)) != 0);
 		return TRUE;
 	}
 
 	/* INTE:TEXT */
-	if (xb_opcode_cmp_val (op1) && xb_opcode_cmp_str (op2)) {
+	if (xb_opcode_cmp_val (&op1) && xb_opcode_cmp_str (&op2)) {
 		guint64 val = 0;
-		if (xb_opcode_get_str (op2) == NULL) {
+		if (xb_opcode_get_str (&op2) == NULL) {
 			xb_stack_push_bool (stack, FALSE);
 			return TRUE;
 		}
-		if (!g_ascii_string_to_unsigned (xb_opcode_get_str (op2),
+		if (!g_ascii_string_to_unsigned (xb_opcode_get_str (&op2),
 						 10, 0, G_MAXUINT32,
 						 &val, error)) {
 			return FALSE;
 		}
-		xb_stack_push_bool (stack, val != xb_opcode_get_val (op1));
+		xb_stack_push_bool (stack, val != xb_opcode_get_val (&op1));
 		return TRUE;
 	}
 
-	/* fail */
-	g_set_error (error,
-		     G_IO_ERROR,
-		     G_IO_ERROR_NOT_SUPPORTED,
-		     "%s:%s types not supported",
-		     xb_opcode_kind_to_string (xb_opcode_get_kind (op1)),
-		     xb_opcode_kind_to_string (xb_opcode_get_kind (op2)));
-	return FALSE;
+	/* Should have been checked above. */
+	g_assert_not_reached ();
 }
 
 static gboolean
@@ -1392,46 +1565,45 @@ xb_machine_func_lt_cb (XbMachine *self,
 		       gpointer exec_data,
 		       GError **error)
 {
-	g_autoptr(XbOpcode) op1 = xb_machine_stack_pop (self, stack);
-	g_autoptr(XbOpcode) op2 = xb_machine_stack_pop (self, stack);
+	g_auto(XbOpcode) op1 = XB_OPCODE_INIT (), op2 = XB_OPCODE_INIT ();
+
+	if (!check_two_args (stack, opcode_cmp_val_or_str, opcode_cmp_val_or_str, error))
+		return FALSE;
+
+	xb_machine_stack_pop (self, stack, &op1);
+	xb_machine_stack_pop (self, stack, &op2);
 
 	/* INTE:INTE */
-	if (xb_opcode_cmp_val (op1) && xb_opcode_cmp_val (op2)) {
-		xb_stack_push_bool (stack, xb_opcode_get_val (op2) < xb_opcode_get_val (op1));
+	if (xb_opcode_cmp_val (&op1) && xb_opcode_cmp_val (&op2)) {
+		xb_stack_push_bool (stack, xb_opcode_get_val (&op2) < xb_opcode_get_val (&op1));
 		return TRUE;
 	}
 
 	/* TEXT:TEXT */
-	if (xb_opcode_cmp_str (op1) && xb_opcode_cmp_str (op2)) {
-		xb_stack_push_bool (stack, g_strcmp0 (xb_opcode_get_str (op2),
-						      xb_opcode_get_str (op1)) < 0);
+	if (xb_opcode_cmp_str (&op1) && xb_opcode_cmp_str (&op2)) {
+		xb_stack_push_bool (stack, g_strcmp0 (xb_opcode_get_str (&op2),
+						      xb_opcode_get_str (&op1)) < 0);
 		return TRUE;
 	}
 
 	/* INTE:TEXT */
-	if (xb_opcode_cmp_val (op1) && xb_opcode_cmp_str (op2)) {
+	if (xb_opcode_cmp_val (&op1) && xb_opcode_cmp_str (&op2)) {
 		guint64 val = 0;
-		if (xb_opcode_get_str (op2) == NULL) {
+		if (xb_opcode_get_str (&op2) == NULL) {
 			xb_stack_push_bool (stack, FALSE);
 			return TRUE;
 		}
-		if (!g_ascii_string_to_unsigned (xb_opcode_get_str (op2),
+		if (!g_ascii_string_to_unsigned (xb_opcode_get_str (&op2),
 						 10, 0, G_MAXUINT32,
 						 &val, error)) {
 			return FALSE;
 		}
-		xb_stack_push_bool (stack, val < xb_opcode_get_val (op1));
+		xb_stack_push_bool (stack, val < xb_opcode_get_val (&op1));
 		return TRUE;
 	}
 
-	/* fail */
-	g_set_error (error,
-		     G_IO_ERROR,
-		     G_IO_ERROR_NOT_SUPPORTED,
-		     "%s:%s types not supported",
-		     xb_opcode_kind_to_string (xb_opcode_get_kind (op1)),
-		     xb_opcode_kind_to_string (xb_opcode_get_kind (op2)));
-	return FALSE;
+	/* Should have been checked above. */
+	g_assert_not_reached ();
 }
 
 static gboolean
@@ -1442,46 +1614,45 @@ xb_machine_func_gt_cb (XbMachine *self,
 		       gpointer exec_data,
 		       GError **error)
 {
-	g_autoptr(XbOpcode) op1 = xb_machine_stack_pop (self, stack);
-	g_autoptr(XbOpcode) op2 = xb_machine_stack_pop (self, stack);
+	g_auto(XbOpcode) op1 = XB_OPCODE_INIT (), op2 = XB_OPCODE_INIT ();
+
+	if (!check_two_args (stack, opcode_cmp_val_or_str, opcode_cmp_val_or_str, error))
+		return FALSE;
+
+	xb_machine_stack_pop (self, stack, &op1);
+	xb_machine_stack_pop (self, stack, &op2);
 
 	/* INTE:INTE */
-	if (xb_opcode_cmp_val (op1) && xb_opcode_cmp_val (op2)) {
-		xb_stack_push_bool (stack, xb_opcode_get_val (op2) > xb_opcode_get_val (op1));
+	if (xb_opcode_cmp_val (&op1) && xb_opcode_cmp_val (&op2)) {
+		xb_stack_push_bool (stack, xb_opcode_get_val (&op2) > xb_opcode_get_val (&op1));
 		return TRUE;
 	}
 
 	/* TEXT:TEXT */
-	if (xb_opcode_cmp_str (op1) && xb_opcode_cmp_str (op2)) {
-		xb_stack_push_bool (stack, g_strcmp0 (xb_opcode_get_str (op2),
-						      xb_opcode_get_str (op1)) > 0);
+	if (xb_opcode_cmp_str (&op1) && xb_opcode_cmp_str (&op2)) {
+		xb_stack_push_bool (stack, g_strcmp0 (xb_opcode_get_str (&op2),
+						      xb_opcode_get_str (&op1)) > 0);
 		return TRUE;
 	}
 
 	/* INTE:TEXT */
-	if (xb_opcode_cmp_val (op1) && xb_opcode_cmp_str (op2)) {
+	if (xb_opcode_cmp_val (&op1) && xb_opcode_cmp_str (&op2)) {
 		guint64 val = 0;
-		if (xb_opcode_get_str (op2) == NULL) {
+		if (xb_opcode_get_str (&op2) == NULL) {
 			xb_stack_push_bool (stack, FALSE);
 			return TRUE;
 		}
-		if (!g_ascii_string_to_unsigned (xb_opcode_get_str (op2),
+		if (!g_ascii_string_to_unsigned (xb_opcode_get_str (&op2),
 						 10, 0, G_MAXUINT32,
 						 &val, error)) {
 			return FALSE;
 		}
-		xb_stack_push_bool (stack, val > xb_opcode_get_val (op1));
+		xb_stack_push_bool (stack, val > xb_opcode_get_val (&op1));
 		return TRUE;
 	}
 
-	/* fail */
-	g_set_error (error,
-		     G_IO_ERROR,
-		     G_IO_ERROR_NOT_SUPPORTED,
-		     "%s:%s types not supported",
-		     xb_opcode_kind_to_string (xb_opcode_get_kind (op1)),
-		     xb_opcode_kind_to_string (xb_opcode_get_kind (op2)));
-	return FALSE;
+	/* Should have been checked above. */
+	g_assert_not_reached ();
 }
 
 static gboolean
@@ -1492,46 +1663,45 @@ xb_machine_func_le_cb (XbMachine *self,
 		       gpointer exec_data,
 		       GError **error)
 {
-	g_autoptr(XbOpcode) op1 = xb_machine_stack_pop (self, stack);
-	g_autoptr(XbOpcode) op2 = xb_machine_stack_pop (self, stack);
+	g_auto(XbOpcode) op1 = XB_OPCODE_INIT (), op2 = XB_OPCODE_INIT ();
+
+	if (!check_two_args (stack, opcode_cmp_val_or_str, opcode_cmp_val_or_str, error))
+		return FALSE;
+
+	xb_machine_stack_pop (self, stack, &op1);
+	xb_machine_stack_pop (self, stack, &op2);
 
 	/* INTE:INTE */
-	if (xb_opcode_cmp_val (op1) && xb_opcode_cmp_val (op2)) {
-		xb_stack_push_bool (stack, xb_opcode_get_val (op2) <= xb_opcode_get_val (op1));
+	if (xb_opcode_cmp_val (&op1) && xb_opcode_cmp_val (&op2)) {
+		xb_stack_push_bool (stack, xb_opcode_get_val (&op2) <= xb_opcode_get_val (&op1));
 		return TRUE;
 	}
 
 	/* TEXT:TEXT */
-	if (xb_opcode_cmp_str (op1) && xb_opcode_cmp_str (op2)) {
-		xb_stack_push_bool (stack, g_strcmp0 (xb_opcode_get_str (op2),
-						      xb_opcode_get_str (op1)) <= 0);
+	if (xb_opcode_cmp_str (&op1) && xb_opcode_cmp_str (&op2)) {
+		xb_stack_push_bool (stack, g_strcmp0 (xb_opcode_get_str (&op2),
+						      xb_opcode_get_str (&op1)) <= 0);
 		return TRUE;
 	}
 
 	/* INTE:TEXT */
-	if (xb_opcode_cmp_val (op1) && xb_opcode_cmp_str (op2)) {
+	if (xb_opcode_cmp_val (&op1) && xb_opcode_cmp_str (&op2)) {
 		guint64 val = 0;
-		if (xb_opcode_get_str (op2) == NULL) {
+		if (xb_opcode_get_str (&op2) == NULL) {
 			xb_stack_push_bool (stack, FALSE);
 			return TRUE;
 		}
-		if (!g_ascii_string_to_unsigned (xb_opcode_get_str (op2),
+		if (!g_ascii_string_to_unsigned (xb_opcode_get_str (&op2),
 						 10, 0, G_MAXUINT32,
 						 &val, error)) {
 			return FALSE;
 		}
-		xb_stack_push_bool (stack, val <= xb_opcode_get_val (op1));
+		xb_stack_push_bool (stack, val <= xb_opcode_get_val (&op1));
 		return TRUE;
 	}
 
-	/* fail */
-	g_set_error (error,
-		     G_IO_ERROR,
-		     G_IO_ERROR_NOT_SUPPORTED,
-		     "%s:%s types not supported",
-		     xb_opcode_kind_to_string (xb_opcode_get_kind (op1)),
-		     xb_opcode_kind_to_string (xb_opcode_get_kind (op2)));
-	return FALSE;
+	/* Should have been checked above. */
+	g_assert_not_reached ();
 }
 
 static gboolean
@@ -1542,22 +1712,17 @@ xb_machine_func_lower_cb (XbMachine *self,
 			  gpointer exec_data,
 			  GError **error)
 {
-	g_autoptr(XbOpcode) op = xb_machine_stack_pop (self, stack);
+	g_auto(XbOpcode) op = XB_OPCODE_INIT ();
+
+	if (!check_one_arg (stack, xb_opcode_cmp_str, error))
+		return FALSE;
+
+	xb_machine_stack_pop (self, stack, &op);
 
 	/* TEXT */
-	if (xb_opcode_cmp_str (op)) {
-		xb_machine_stack_push_text_steal (self, stack,
-						  g_ascii_strdown (xb_opcode_get_str (op), -1));
-		return TRUE;
-	}
-
-	/* fail */
-	g_set_error (error,
-		     G_IO_ERROR,
-		     G_IO_ERROR_NOT_SUPPORTED,
-		     "%s type not supported",
-		     xb_opcode_kind_to_string (xb_opcode_get_kind (op)));
-	return FALSE;
+	return xb_machine_stack_push_text_steal (self, stack,
+						 g_ascii_strdown (xb_opcode_get_str (&op), -1),
+						 error);
 }
 
 static gboolean
@@ -1568,22 +1733,17 @@ xb_machine_func_upper_cb (XbMachine *self,
 			  gpointer exec_data,
 			  GError **error)
 {
-	g_autoptr(XbOpcode) op = xb_machine_stack_pop (self, stack);
+	g_auto(XbOpcode) op = XB_OPCODE_INIT ();
+
+	if (!check_one_arg (stack, xb_opcode_cmp_str, error))
+		return FALSE;
+
+	xb_machine_stack_pop (self, stack, &op);
 
 	/* TEXT */
-	if (xb_opcode_cmp_str (op)) {
-		xb_machine_stack_push_text_steal (self, stack,
-						  g_ascii_strup (xb_opcode_get_str (op), -1));
-		return TRUE;
-	}
-
-	/* fail */
-	g_set_error (error,
-		     G_IO_ERROR,
-		     G_IO_ERROR_NOT_SUPPORTED,
-		     "%s type not supported",
-		     xb_opcode_kind_to_string (xb_opcode_get_kind (op)));
-	return FALSE;
+	return xb_machine_stack_push_text_steal (self, stack,
+						 g_ascii_strup (xb_opcode_get_str (&op), -1),
+						 error);
 }
 
 static gboolean
@@ -1594,27 +1754,27 @@ xb_machine_func_not_cb (XbMachine *self,
 			gpointer exec_data,
 			GError **error)
 {
-	g_autoptr(XbOpcode) op1 = xb_machine_stack_pop (self, stack);
+	g_auto(XbOpcode) op = XB_OPCODE_INIT ();
+
+	if (!check_one_arg (stack, opcode_cmp_val_or_str, error))
+		return FALSE;
+
+	xb_machine_stack_pop (self, stack, &op);
 
 	/* TEXT */
-	if (xb_opcode_cmp_str (op1)) {
-		xb_stack_push_bool (stack, xb_opcode_get_str (op1) == NULL);
+	if (xb_opcode_cmp_str (&op)) {
+		xb_stack_push_bool (stack, xb_opcode_get_str (&op) == NULL);
 		return TRUE;
 	}
 
 	/* INTE */
-	if (xb_opcode_cmp_val (op1)) {
-		xb_stack_push_bool (stack, xb_opcode_get_val (op1) == 0);
+	if (xb_opcode_cmp_val (&op)) {
+		xb_stack_push_bool (stack, xb_opcode_get_val (&op) == 0);
 		return TRUE;
 	}
 
-	/* fail */
-	g_set_error (error,
-		     G_IO_ERROR,
-		     G_IO_ERROR_NOT_SUPPORTED,
-		     "%s type not supported",
-		     xb_opcode_kind_to_string (xb_opcode_get_kind (op1)));
-	return FALSE;
+	/* Should have been checked above. */
+	g_assert_not_reached ();
 }
 
 static gboolean
@@ -1625,46 +1785,45 @@ xb_machine_func_ge_cb (XbMachine *self,
 		       gpointer exec_data,
 		       GError **error)
 {
-	g_autoptr(XbOpcode) op1 = xb_machine_stack_pop (self, stack);
-	g_autoptr(XbOpcode) op2 = xb_machine_stack_pop (self, stack);
+	g_auto(XbOpcode) op1 = XB_OPCODE_INIT (), op2 = XB_OPCODE_INIT ();
+
+	if (!check_two_args (stack, opcode_cmp_val_or_str, opcode_cmp_val_or_str, error))
+		return FALSE;
+
+	xb_machine_stack_pop (self, stack, &op1);
+	xb_machine_stack_pop (self, stack, &op2);
 
 	/* TEXT:TEXT */
-	if (xb_opcode_cmp_str (op1) && xb_opcode_cmp_str (op2)) {
-		xb_stack_push_bool (stack, g_strcmp0 (xb_opcode_get_str (op2),
-						      xb_opcode_get_str (op1)) >= 0);
+	if (xb_opcode_cmp_str (&op1) && xb_opcode_cmp_str (&op2)) {
+		xb_stack_push_bool (stack, g_strcmp0 (xb_opcode_get_str (&op2),
+						      xb_opcode_get_str (&op1)) >= 0);
 		return TRUE;
 	}
 
 	/* INTE:INTE */
-	if (xb_opcode_cmp_val (op1) && xb_opcode_cmp_val (op2)) {
-		xb_stack_push_bool (stack, xb_opcode_get_val (op2) >= xb_opcode_get_val (op1));
+	if (xb_opcode_cmp_val (&op1) && xb_opcode_cmp_val (&op2)) {
+		xb_stack_push_bool (stack, xb_opcode_get_val (&op2) >= xb_opcode_get_val (&op1));
 		return TRUE;
 	}
 
 	/* INTE:TEXT */
-	if (xb_opcode_cmp_val (op1) && xb_opcode_cmp_str (op2)) {
+	if (xb_opcode_cmp_val (&op1) && xb_opcode_cmp_str (&op2)) {
 		guint64 val = 0;
-		if (xb_opcode_get_str (op2) == NULL) {
+		if (xb_opcode_get_str (&op2) == NULL) {
 			xb_stack_push_bool (stack, FALSE);
 			return TRUE;
 		}
-		if (!g_ascii_string_to_unsigned (xb_opcode_get_str (op2),
+		if (!g_ascii_string_to_unsigned (xb_opcode_get_str (&op2),
 						 10, 0, G_MAXUINT32,
 						 &val, error)) {
 			return FALSE;
 		}
-		xb_stack_push_bool (stack, val >= xb_opcode_get_val (op1));
+		xb_stack_push_bool (stack, val >= xb_opcode_get_val (&op1));
 		return TRUE;
 	}
 
-	/* fail */
-	g_set_error (error,
-		     G_IO_ERROR,
-		     G_IO_ERROR_NOT_SUPPORTED,
-		     "%s:%s types not supported",
-		     xb_opcode_kind_to_string (xb_opcode_get_kind (op1)),
-		     xb_opcode_kind_to_string (xb_opcode_get_kind (op2)));
-	return FALSE;
+	/* Should have been checked above. */
+	g_assert_not_reached ();
 }
 
 static gboolean
@@ -1675,24 +1834,17 @@ xb_machine_func_contains_cb (XbMachine *self,
 			     gpointer exec_data,
 			     GError **error)
 {
-	g_autoptr(XbOpcode) op1 = xb_machine_stack_pop (self, stack);
-	g_autoptr(XbOpcode) op2 = xb_machine_stack_pop (self, stack);
+	g_auto(XbOpcode) op1 = XB_OPCODE_INIT (), op2 = XB_OPCODE_INIT ();
+
+	if (!check_two_args (stack, xb_opcode_cmp_str, xb_opcode_cmp_str, error))
+		return FALSE;
+
+	xb_machine_stack_pop (self, stack, &op1);
+	xb_machine_stack_pop (self, stack, &op2);
 
 	/* TEXT:TEXT */
-	if (xb_opcode_cmp_str (op1) && xb_opcode_cmp_str (op2)) {
-		xb_stack_push_bool (stack, xb_string_contains (xb_opcode_get_str (op2),
-							       xb_opcode_get_str (op1)));
-		return TRUE;
-	}
-
-	/* fail */
-	g_set_error (error,
-		     G_IO_ERROR,
-		     G_IO_ERROR_NOT_SUPPORTED,
-		     "%s:%s types not supported",
-		     xb_opcode_kind_to_string (xb_opcode_get_kind (op1)),
-		     xb_opcode_kind_to_string (xb_opcode_get_kind (op2)));
-	return FALSE;
+	return xb_stack_push_bool (stack, xb_string_contains (xb_opcode_get_str (&op2),
+							      xb_opcode_get_str (&op1)));
 }
 
 static gboolean
@@ -1703,24 +1855,17 @@ xb_machine_func_starts_with_cb (XbMachine *self,
 			        gpointer exec_data,
 			        GError **error)
 {
-	g_autoptr(XbOpcode) op1 = xb_machine_stack_pop (self, stack);
-	g_autoptr(XbOpcode) op2 = xb_machine_stack_pop (self, stack);
+	g_auto(XbOpcode) op1 = XB_OPCODE_INIT (), op2 = XB_OPCODE_INIT ();
+
+	if (!check_two_args (stack, xb_opcode_cmp_str, xb_opcode_cmp_str, error))
+		return FALSE;
+
+	xb_machine_stack_pop (self, stack, &op1);
+	xb_machine_stack_pop (self, stack, &op2);
 
 	/* TEXT:TEXT */
-	if (xb_opcode_cmp_str (op1) && xb_opcode_cmp_str (op2)) {
-		xb_stack_push_bool (stack, g_str_has_prefix (xb_opcode_get_str (op2),
-							     xb_opcode_get_str (op1)));
-		return TRUE;
-	}
-
-	/* fail */
-	g_set_error (error,
-		     G_IO_ERROR,
-		     G_IO_ERROR_NOT_SUPPORTED,
-		     "%s:%s types not supported",
-		     xb_opcode_kind_to_string (xb_opcode_get_kind (op1)),
-		     xb_opcode_kind_to_string (xb_opcode_get_kind (op2)));
-	return FALSE;
+	return xb_stack_push_bool (stack, g_str_has_prefix (xb_opcode_get_str (&op2),
+							    xb_opcode_get_str (&op1)));
 }
 
 static gboolean
@@ -1731,24 +1876,17 @@ xb_machine_func_ends_with_cb (XbMachine *self,
 			      gpointer exec_data,
 			      GError **error)
 {
-	g_autoptr(XbOpcode) op1 = xb_machine_stack_pop (self, stack);
-	g_autoptr(XbOpcode) op2 = xb_machine_stack_pop (self, stack);
+	g_auto(XbOpcode) op1 = XB_OPCODE_INIT (), op2 = XB_OPCODE_INIT ();
+
+	if (!check_two_args (stack, xb_opcode_cmp_str, xb_opcode_cmp_str, error))
+		return FALSE;
+
+	xb_machine_stack_pop (self, stack, &op1);
+	xb_machine_stack_pop (self, stack, &op2);
 
 	/* TEXT:TEXT */
-	if (xb_opcode_cmp_str (op1) && xb_opcode_cmp_str (op2)) {
-		xb_stack_push_bool (stack, g_str_has_suffix (xb_opcode_get_str (op2),
-							     xb_opcode_get_str (op1)));
-		return TRUE;
-	}
-
-	/* fail */
-	g_set_error (error,
-		     G_IO_ERROR,
-		     G_IO_ERROR_NOT_SUPPORTED,
-		     "%s:%s types not supported",
-		     xb_opcode_kind_to_string (xb_opcode_get_kind (op1)),
-		     xb_opcode_kind_to_string (xb_opcode_get_kind (op2)));
-	return FALSE;
+	return xb_stack_push_bool (stack, g_str_has_suffix (xb_opcode_get_str (&op2),
+							    xb_opcode_get_str (&op1)));
 }
 
 static gboolean
@@ -1759,31 +1897,25 @@ xb_machine_func_number_cb (XbMachine *self,
 			   gpointer exec_data,
 			   GError **error)
 {
-	g_autoptr(XbOpcode) op1 = xb_machine_stack_pop (self, stack);
+	g_auto(XbOpcode) op = XB_OPCODE_INIT ();
+	guint64 val = 0;
+
+	if (!check_one_arg (stack, xb_opcode_cmp_str, error))
+		return FALSE;
+
+	xb_machine_stack_pop (self, stack, &op);
 
 	/* TEXT */
-	if (xb_opcode_cmp_str (op1)) {
-		guint64 val = 0;
-		if (xb_opcode_get_str (op1) == NULL) {
-			xb_stack_push_bool (stack, FALSE);
-			return TRUE;
-		}
-		if (!g_ascii_string_to_unsigned (xb_opcode_get_str (op1),
-						 10, 0, G_MAXUINT32,
-						 &val, error)) {
-			return FALSE;
-		}
-		xb_machine_stack_push_integer (self, stack, val);
+	if (xb_opcode_get_str (&op) == NULL) {
+		xb_stack_push_bool (stack, FALSE);
 		return TRUE;
 	}
-
-	/* fail */
-	g_set_error (error,
-		     G_IO_ERROR,
-		     G_IO_ERROR_NOT_SUPPORTED,
-		     "%s types not supported",
-		     xb_opcode_kind_to_string (xb_opcode_get_kind (op1)));
-	return FALSE;
+	if (!g_ascii_string_to_unsigned (xb_opcode_get_str (&op),
+					 10, 0, G_MAXUINT32,
+					 &val, error)) {
+		return FALSE;
+	}
+	return xb_machine_stack_push_integer (self, stack, val, error);
 }
 
 static gboolean
@@ -1794,25 +1926,18 @@ xb_machine_func_strlen_cb (XbMachine *self,
 			   gpointer exec_data,
 			   GError **error)
 {
-	g_autoptr(XbOpcode) op1 = xb_machine_stack_pop (self, stack);
+	g_auto(XbOpcode) op = XB_OPCODE_INIT ();
+
+	if (!check_one_arg (stack, xb_opcode_cmp_str, error))
+		return FALSE;
+
+	xb_machine_stack_pop (self, stack, &op);
 
 	/* TEXT */
-	if (xb_opcode_cmp_str (op1)) {
-		if (xb_opcode_get_str (op1) == NULL) {
-			xb_stack_push_bool (stack, FALSE);
-			return TRUE;
-		}
-		xb_machine_stack_push_integer (self, stack, strlen (xb_opcode_get_str (op1)));
-		return TRUE;
+	if (xb_opcode_get_str (&op) == NULL) {
+		return xb_stack_push_bool (stack, FALSE);
 	}
-
-	/* fail */
-	g_set_error (error,
-		     G_IO_ERROR,
-		     G_IO_ERROR_NOT_SUPPORTED,
-		     "%s types not supported",
-		     xb_opcode_kind_to_string (xb_opcode_get_kind (op1)));
-	return FALSE;
+	return xb_machine_stack_push_integer (self, stack, strlen (xb_opcode_get_str (&op)), error);
 }
 
 static gboolean
@@ -1823,23 +1948,17 @@ xb_machine_func_string_cb (XbMachine *self,
 			   gpointer exec_data,
 			   GError **error)
 {
-	g_autoptr(XbOpcode) op1 = xb_machine_stack_pop (self, stack);
+	g_auto(XbOpcode) op = XB_OPCODE_INIT ();
+	gchar *tmp;
+
+	if (!check_one_arg (stack, xb_opcode_cmp_val, error))
+		return FALSE;
+
+	xb_machine_stack_pop (self, stack, &op);
 
 	/* INTE */
-	if (xb_opcode_cmp_val (op1)) {
-		gchar *tmp = g_strdup_printf ("%" G_GUINT32_FORMAT,
-					      xb_opcode_get_val (op1));
-		xb_machine_stack_push_text_steal (self, stack, tmp);
-		return TRUE;
-	}
-
-	/* fail */
-	g_set_error (error,
-		     G_IO_ERROR,
-		     G_IO_ERROR_NOT_SUPPORTED,
-		     "%s types not supported",
-		     xb_opcode_kind_to_string (xb_opcode_get_kind (op1)));
-	return FALSE;
+	tmp = g_strdup_printf ("%" G_GUINT32_FORMAT, xb_opcode_get_val (&op));
+	return xb_machine_stack_push_text_steal (self, stack, tmp, error);
 }
 
 static void

--- a/src/xb-machine.c
+++ b/src/xb-machine.c
@@ -577,7 +577,7 @@ xb_machine_opcodes_optimize_fn (XbMachine *self,
 	stack_str = xb_stack_to_string (stack);
 	if (!item->method_cb (self, stack, NULL, item->user_data, NULL, &error_local)) {
 		if (priv->debug_flags & XB_MACHINE_DEBUG_FLAG_SHOW_OPTIMIZER) {
-			g_debug ("ignoring opimized call to %s(%s): %s",
+			g_debug ("ignoring optimized call to %s(%s): %s",
 				 item->name,
 				 stack_str,
 				 error_local->message);

--- a/src/xb-machine.h
+++ b/src/xb-machine.h
@@ -115,8 +115,12 @@ void		 xb_machine_add_operator	(XbMachine		*self,
 						 const gchar		*str,
 						 const gchar		*name);
 
-XbOpcode	*xb_machine_opcode_func_new	(XbMachine		*self,
+gboolean	 xb_machine_opcode_func_init	(XbMachine		*self,
+						 XbOpcode		*opcode,
 						 const gchar		*func_name);
+G_DEPRECATED_FOR(xb_machine_opcode_func_init)
+XbOpcode	*xb_machine_opcode_func_new	(XbMachine		*self,
+						 const gchar		*func_name) G_GNUC_NORETURN;
 gchar		*xb_machine_opcode_to_string	(XbMachine		*self,
 						 XbOpcode		*opcode)
 G_DEPRECATED_FOR(xb_opcode_to_string);
@@ -124,26 +128,33 @@ gchar		*xb_machine_opcodes_to_string	(XbMachine		*self,
 						 XbStack		*opcodes)
 G_DEPRECATED_FOR(xb_stack_to_string);
 
-XbOpcode	*xb_machine_stack_pop		(XbMachine		*self,
-						 XbStack		*stack);
-void		 xb_machine_stack_push		(XbMachine		*self,
+gboolean	 xb_machine_stack_pop		(XbMachine		*self,
 						 XbStack		*stack,
-						 XbOpcode		*opcode);
+						 XbOpcode		*opcode_out);
+gboolean	 xb_machine_stack_push		(XbMachine		*self,
+						 XbStack		*stack,
+						 XbOpcode		**opcode_out,
+						 GError			**error);
+G_DEPRECATED_FOR(xb_machine_stach_push)
 void		 xb_machine_stack_push_steal	(XbMachine		*self,
 						 XbStack		*stack,
-						 XbOpcode		*opcode);
-void		 xb_machine_stack_push_text	(XbMachine		*self,
+						 XbOpcode		*opcode) G_GNUC_NORETURN;
+gboolean	 xb_machine_stack_push_text	(XbMachine		*self,
 						 XbStack		*stack,
-						 const gchar		*str);
-void		 xb_machine_stack_push_text_static (XbMachine		*self,
+						 const gchar		*str,
+						 GError			**error);
+gboolean	 xb_machine_stack_push_text_static (XbMachine		*self,
 						 XbStack		*stack,
-						 const gchar		*str);
-void		 xb_machine_stack_push_text_steal (XbMachine		*self,
+						 const gchar		*str,
+						 GError			**error);
+gboolean	 xb_machine_stack_push_text_steal (XbMachine		*self,
 						 XbStack		*stack,
-						 gchar			*str);
-void		 xb_machine_stack_push_integer	(XbMachine		*self,
+						 gchar			*str,
+						 GError			**error);
+gboolean	 xb_machine_stack_push_integer	(XbMachine		*self,
 						 XbStack		*stack,
-						 guint32		 val);
+						 guint32		 val,
+						 GError			**error);
 void		 xb_machine_set_stack_size	(XbMachine		*self,
 						 guint			 stack_size);
 guint		 xb_machine_get_stack_size	(XbMachine		*self);

--- a/src/xb-opcode-private.h
+++ b/src/xb-opcode-private.h
@@ -10,11 +10,47 @@
 
 G_BEGIN_DECLS
 
-XbOpcode	*xb_opcode_new			(XbOpcodeKind	 kind,
+struct _XbOpcode {
+	XbOpcodeKind	 kind;
+	guint32		 val;
+	gpointer	 ptr;
+	GDestroyNotify	 destroy_func;
+};
+
+#define XB_OPCODE_INIT() { 0, 0, NULL, NULL }
+
+/**
+ * xb_opcode_steal:
+ * @op_ptr: (transfer full): pointer to an #XbOpcode to steal
+ *
+ * Steal the stack-allocated #XbOpcode pointed to by @op_ptr, returning its
+ * value and clearing its previous storage location using `memset()`.
+ *
+ * Returns: the value of @op_ptr
+ * Since: 0.2.0
+ */
+static inline XbOpcode
+xb_opcode_steal (XbOpcode *op_ptr)
+{
+  XbOpcode op = *op_ptr;
+  memset (op_ptr, 0, sizeof (XbOpcode));
+  return op;
+}
+
+void		 xb_opcode_init			(XbOpcode	*opcode,
+						 XbOpcodeKind	 kind,
 						 const gchar	*str,
 						 guint32	 val,
 						 GDestroyNotify	 destroy_func);
-XbOpcode	*xb_opcode_bind_new		(void);
+void		 xb_opcode_clear		(XbOpcode	*opcode);
+G_DEPRECATED_FOR(xb_opcode_init)
+XbOpcode	*xb_opcode_new			(XbOpcodeKind	 kind,
+						 const gchar	*str,
+						 guint32	 val,
+						 GDestroyNotify	 destroy_func) G_GNUC_NORETURN;
+void		 xb_opcode_bind_init		(XbOpcode	*opcode);
+G_DEPRECATED_FOR(xb_opcode_bind_init)
+XbOpcode	*xb_opcode_bind_new		(void) G_GNUC_NORETURN;
 gboolean	 xb_opcode_is_bound		(XbOpcode	*self);
 void		 xb_opcode_bind_str		(XbOpcode	*self,
 						 gchar		*str,
@@ -26,6 +62,10 @@ void		 xb_opcode_set_kind		(XbOpcode	*self,
 void		 xb_opcode_set_val		(XbOpcode	*self,
 						 guint32	 val);
 gchar		*xb_opcode_get_sig		(XbOpcode	*self);
+void		 xb_opcode_bool_init		(XbOpcode	*opcode,
+						 gboolean	 val);
 XbOpcode	*xb_opcode_bool_new		(gboolean	 val);
+
+G_DEFINE_AUTO_CLEANUP_CLEAR_FUNC (XbOpcode, xb_opcode_clear)
 
 G_END_DECLS

--- a/src/xb-opcode.h
+++ b/src/xb-opcode.h
@@ -72,18 +72,35 @@ gchar		*xb_opcode_to_string		(XbOpcode	*self);
 const gchar	*xb_opcode_kind_to_string	(XbOpcodeKind	 kind);
 XbOpcodeKind	 xb_opcode_kind_from_string	(const gchar	*str);
 
-void		 xb_opcode_unref		(XbOpcode	*self);
-XbOpcode	*xb_opcode_ref			(XbOpcode	*self);
+G_DEPRECATED_FOR(xb_opcode_clear)
+void		 xb_opcode_unref		(XbOpcode	*self) G_GNUC_NORETURN;
+G_DEPRECATED
+XbOpcode	*xb_opcode_ref			(XbOpcode	*self) G_GNUC_NORETURN;
 
 XbOpcodeKind	 xb_opcode_get_kind		(XbOpcode	*self);
 const gchar	*xb_opcode_get_str		(XbOpcode	*self);
 guint32		 xb_opcode_get_val		(XbOpcode	*self);
 
-XbOpcode	*xb_opcode_func_new		(guint32	 func);
-XbOpcode	*xb_opcode_integer_new		(guint32	 val);
-XbOpcode	*xb_opcode_text_new		(const gchar	*str);
-XbOpcode	*xb_opcode_text_new_static	(const gchar	*str);
-XbOpcode	*xb_opcode_text_new_steal	(gchar		*str);
+void		 xb_opcode_func_init		(XbOpcode	*opcode,
+						 guint32	 func);
+G_DEPRECATED_FOR(xb_opcode_func_init)
+XbOpcode	*xb_opcode_func_new		(guint32	 func) G_GNUC_NORETURN;
+void		 xb_opcode_integer_init		(XbOpcode	*opcode,
+						 guint32	 val);
+G_DEPRECATED_FOR(xb_opcode_integer_init)
+XbOpcode	*xb_opcode_integer_new		(guint32	 val) G_GNUC_NORETURN;
+void		 xb_opcode_text_init		(XbOpcode	*opcode,
+						 const gchar	*str);
+G_DEPRECATED_FOR(xb_opcode_text_init)
+XbOpcode	*xb_opcode_text_new		(const gchar	*str) G_GNUC_NORETURN;
+void		 xb_opcode_text_init_static	(XbOpcode	*opcode,
+						 const gchar	*str);
+G_DEPRECATED_FOR(xb_opcode_text_init_static)
+XbOpcode	*xb_opcode_text_new_static	(const gchar	*str) G_GNUC_NORETURN;
+void		 xb_opcode_text_init_steal	(XbOpcode	*opcode,
+						 gchar		*str);
+G_DEPRECATED_FOR(xb_opcode_text_init_steal)
+XbOpcode	*xb_opcode_text_new_steal	(gchar		*str) G_GNUC_NORETURN;
 
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(XbOpcode, xb_opcode_unref)
 

--- a/src/xb-silo.c
+++ b/src/xb-silo.c
@@ -954,6 +954,21 @@ xb_silo_node_create (XbSilo *self, XbSiloNode *sn)
 	return n;
 }
 
+/* Push two opcodes onto the stack with appropriate rollback on failure. */
+static gboolean
+stack_push_two (XbStack *opcodes,
+		XbOpcode **op1,
+		XbOpcode **op2)
+{
+	if (!xb_stack_push (opcodes, op1))
+		return FALSE;
+	if (!xb_stack_push (opcodes, op2)) {
+		xb_stack_pop (opcodes, NULL);
+		return FALSE;
+	}
+	return TRUE;
+}
+
 /* convert [2] to position()=2 */
 static gboolean
 xb_silo_machine_fixup_position_cb (XbMachine *self,
@@ -961,8 +976,13 @@ xb_silo_machine_fixup_position_cb (XbMachine *self,
 				   gpointer user_data,
 				   GError **error)
 {
-	xb_stack_push_steal (opcodes, xb_machine_opcode_func_new (self, "position"));
-	xb_stack_push_steal (opcodes, xb_machine_opcode_func_new (self, "eq"));
+	XbOpcode *op1, *op2;
+	if (!stack_push_two (opcodes, &op1, &op2))
+		return FALSE;
+
+	xb_machine_opcode_func_init (self, op1, "position");
+	xb_machine_opcode_func_init (self, op2, "eq");
+
 	return TRUE;
 }
 
@@ -973,8 +993,13 @@ xb_silo_machine_fixup_attr_exists_cb (XbMachine *self,
 				      gpointer user_data,
 				      GError **error)
 {
-	xb_stack_push_steal (opcodes, xb_opcode_text_new_static (NULL));
-	xb_stack_push_steal (opcodes, xb_machine_opcode_func_new (self, "ne"));
+	XbOpcode *op1, *op2;
+	if (!stack_push_two (opcodes, &op1, &op2))
+		return FALSE;
+
+	xb_opcode_text_init_static (op1, NULL);
+	xb_machine_opcode_func_init (self, op2, "ne");
+
 	return TRUE;
 }
 
@@ -990,7 +1015,7 @@ xb_silo_machine_func_attr_cb (XbMachine *self,
 	XbSiloAttr *a;
 	XbSilo *silo = XB_SILO (user_data);
 	XbSiloQueryData *query_data = (XbSiloQueryData *) exec_data;
-	g_autoptr(XbOpcode) op = xb_machine_stack_pop (self, stack);
+	g_auto(XbOpcode) op = { 0, };
 
 	/* optimize pass */
 	if (query_data == NULL) {
@@ -999,23 +1024,25 @@ xb_silo_machine_func_attr_cb (XbMachine *self,
 		return FALSE;
 	}
 
+	xb_machine_stack_pop (self, stack, &op);
+
 	/* indexed string */
-	if (xb_opcode_get_kind (op) == XB_OPCODE_KIND_INDEXED_TEXT) {
-		guint32 val = xb_opcode_get_val (op);
+	if (xb_opcode_get_kind (&op) == XB_OPCODE_KIND_INDEXED_TEXT) {
+		guint32 val = xb_opcode_get_val (&op);
 		a = xb_silo_node_get_attr_by_val (silo, query_data->sn, val);
 	} else {
-		const gchar *str = xb_opcode_get_str (op);
+		const gchar *str = xb_opcode_get_str (&op);
 		a = xb_silo_node_get_attr_by_str (silo, query_data->sn, str);
 	}
 	if (a == NULL) {
-		xb_machine_stack_push_text_static (self, stack, NULL);
-		return TRUE;
+		return xb_machine_stack_push_text_static (self, stack, NULL, error);
 	}
-	op2 = xb_opcode_new (XB_OPCODE_KIND_INDEXED_TEXT,
+	if (!xb_machine_stack_push (self, stack, &op2, error))
+		return FALSE;
+	xb_opcode_init (op2, XB_OPCODE_KIND_INDEXED_TEXT,
 			     xb_silo_from_strtab (silo, a->attr_value),
 			     a->attr_value,
 			     NULL);
-	xb_machine_stack_push_steal (self, stack, op2);
 	return TRUE;
 }
 
@@ -1028,22 +1055,25 @@ xb_silo_machine_func_stem_cb (XbMachine *self,
 			      GError **error)
 {
 	XbSilo *silo = XB_SILO (user_data);
-	g_autoptr(XbOpcode) op = xb_machine_stack_pop (self, stack);
+	g_auto(XbOpcode) op = { 0, };
+	XbOpcode *head;
+	const gchar *str;
 
-	/* TEXT */
-	if (xb_opcode_cmp_str (op)) {
-		const gchar *str = xb_opcode_get_str (op);
-		xb_machine_stack_push_text_steal (self, stack, xb_silo_stem (silo, str));
-		return TRUE;
+	head = xb_stack_peek_head (stack);
+	if (head == NULL || !xb_opcode_cmp_str (head)) {
+		g_set_error (error,
+			     G_IO_ERROR,
+			     G_IO_ERROR_NOT_SUPPORTED,
+			     "%s type not supported",
+			     (head != NULL) ? xb_opcode_kind_to_string (xb_opcode_get_kind (head)) : "(null)");
+		return FALSE;
 	}
 
-	/* fail */
-	g_set_error (error,
-		     G_IO_ERROR,
-		     G_IO_ERROR_NOT_SUPPORTED,
-		     "%s type not supported",
-		     xb_opcode_kind_to_string (xb_opcode_get_kind (op)));
-	return FALSE;
+	xb_machine_stack_pop (self, stack, &op);
+
+	/* TEXT */
+	str = xb_opcode_get_str (&op);
+	return xb_machine_stack_push_text_steal (self, stack, xb_silo_stem (silo, str), error);
 }
 
 static gboolean
@@ -1056,6 +1086,7 @@ xb_silo_machine_func_text_cb (XbMachine *self,
 {
 	XbSilo *silo = XB_SILO (user_data);
 	XbSiloQueryData *query_data = (XbSiloQueryData *) exec_data;
+	XbOpcode *op;
 
 	/* optimize pass */
 	if (query_data == NULL) {
@@ -1063,11 +1094,13 @@ xb_silo_machine_func_text_cb (XbMachine *self,
 				     "cannot optimize: no silo to query");
 		return FALSE;
 	}
-	xb_machine_stack_push_steal (self, stack,
-				     xb_opcode_new (XB_OPCODE_KIND_INDEXED_TEXT,
+
+	if (!xb_machine_stack_push (self, stack, &op, error))
+		return FALSE;
+	xb_opcode_init (op, XB_OPCODE_KIND_INDEXED_TEXT,
 						    xb_silo_node_get_text (silo, query_data->sn),
 						    query_data->sn->text,
-						    NULL));
+						    NULL);
 	return TRUE;
 }
 
@@ -1081,6 +1114,7 @@ xb_silo_machine_func_tail_cb (XbMachine *self,
 {
 	XbSilo *silo = XB_SILO (user_data);
 	XbSiloQueryData *query_data = (XbSiloQueryData *) exec_data;
+	XbOpcode *op;
 
 	/* optimize pass */
 	if (query_data == NULL) {
@@ -1088,11 +1122,13 @@ xb_silo_machine_func_tail_cb (XbMachine *self,
 				     "cannot optimize: no silo to query");
 		return FALSE;
 	}
-	xb_machine_stack_push_steal (self, stack,
-				     xb_opcode_new (XB_OPCODE_KIND_INDEXED_TEXT,
+
+	if (!xb_machine_stack_push (self, stack, &op, error))
+		return FALSE;
+	xb_opcode_init (op, XB_OPCODE_KIND_INDEXED_TEXT,
 						    xb_silo_node_get_tail (silo, query_data->sn),
 						    query_data->sn->tail,
-						    NULL));
+						    NULL);
 	return TRUE;
 }
 
@@ -1152,8 +1188,7 @@ xb_silo_machine_func_position_cb (XbMachine *self,
 				     "cannot optimize: no silo to query");
 		return FALSE;
 	}
-	xb_machine_stack_push_integer (self, stack, query_data->position);
-	return TRUE;
+	return xb_machine_stack_push_integer (self, stack, query_data->position, error);
 }
 
 static gboolean
@@ -1164,24 +1199,31 @@ xb_silo_machine_func_search_cb (XbMachine *self,
 				gpointer exec_data,
 				GError **error)
 {
-	g_autoptr(XbOpcode) op1 = xb_machine_stack_pop (self, stack);
-	g_autoptr(XbOpcode) op2 = xb_machine_stack_pop (self, stack);
+	g_auto(XbOpcode) op1 = { 0, }, op2 = { 0, };
+	XbOpcode *head1 = NULL, *head2 = NULL;
 
-	/* TEXT:TEXT */
-	if (xb_opcode_cmp_str (op1) && xb_opcode_cmp_str (op2)) {
-		xb_stack_push_bool (stack, xb_string_search (xb_opcode_get_str (op2),
-							     xb_opcode_get_str (op1)));
-		return TRUE;
+	if (xb_stack_get_size (stack) >= 2) {
+		head1 = xb_stack_peek (stack, xb_stack_get_size (stack) - 1);
+		head2 = xb_stack_peek (stack, xb_stack_get_size (stack) - 2);
+	}
+	if (head1 == NULL || !xb_opcode_cmp_str (head1) ||
+	    head2 == NULL || !xb_opcode_cmp_str (head2)) {
+		g_set_error (error,
+			     G_IO_ERROR,
+			     G_IO_ERROR_NOT_SUPPORTED,
+			     "%s:%s types not supported",
+			     (head1 != NULL) ? xb_opcode_kind_to_string (xb_opcode_get_kind (head1)) : "(null)",
+			     (head2 != NULL) ? xb_opcode_kind_to_string (xb_opcode_get_kind (head2)) : "(null)");
+		return FALSE;
 	}
 
-	/* fail */
-	g_set_error (error,
-		     G_IO_ERROR,
-		     G_IO_ERROR_NOT_SUPPORTED,
-		     "%s:%s types not supported",
-		     xb_opcode_kind_to_string (xb_opcode_get_kind (op1)),
-		     xb_opcode_kind_to_string (xb_opcode_get_kind (op2)));
-	return FALSE;
+	xb_machine_stack_pop (self, stack, &op1);
+	xb_machine_stack_pop (self, stack, &op2);
+
+	/* TEXT:TEXT */
+	xb_stack_push_bool (stack, xb_string_search (xb_opcode_get_str (&op2),
+						     xb_opcode_get_str (&op1)));
+	return TRUE;
 }
 
 static gboolean
@@ -1194,17 +1236,22 @@ xb_silo_machine_fixup_attr_text_cb (XbMachine *self,
 {
 	/* @foo -> attr(foo) */
 	if (g_str_has_prefix (text, "@")) {
-		XbOpcode *opcode;
-		opcode = xb_machine_opcode_func_new (self, "attr");
-		if (opcode == NULL) {
+		XbOpcode *op1, *op2;
+
+		if (!stack_push_two (opcodes, &op1, &op2))
+			return FALSE;
+
+		xb_opcode_text_init (op1, text + 1);
+		if (!xb_machine_opcode_func_init (self, op2, "attr")) {
 			g_set_error_literal (error,
 					     G_IO_ERROR,
 					     G_IO_ERROR_NOT_SUPPORTED,
 					     "no attr opcode");
+			xb_stack_pop (opcodes, NULL);
+			xb_stack_pop (opcodes, NULL);
 			return FALSE;
 		}
-		xb_stack_push_steal (opcodes, xb_opcode_text_new (text + 1));
-		xb_stack_push_steal (opcodes, opcode);
+
 		*handled = TRUE;
 		return TRUE;
 	}

--- a/src/xb-stack-private.h
+++ b/src/xb-stack-private.h
@@ -23,7 +23,7 @@ XbOpcode	*xb_stack_peek			(XbStack	*self,
 						 guint		 idx);
 XbOpcode	*xb_stack_peek_head		(XbStack	*self);
 XbOpcode	*xb_stack_peek_tail		(XbStack	*self);
-GPtrArray	*xb_stack_steal_all		(XbStack	*self);
+GArray		*xb_stack_steal_all		(XbStack	*self);
 
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(XbStack, xb_stack_unref)
 

--- a/src/xb-stack.c
+++ b/src/xb-stack.c
@@ -15,9 +15,9 @@
 
 struct _XbStack {
 	gint		 ref;
-	guint		 pos;
+	guint		 pos;	/* index of the next unused entry in .opcodes */
 	guint		 max_size;
-	XbOpcode	*opcodes[];	/* allocated as part of XbStack */
+	XbOpcode	 opcodes[];	/* allocated as part of XbStack */
 };
 
 /**
@@ -36,7 +36,7 @@ xb_stack_unref (XbStack *self)
 	if (--self->ref > 0)
 		return;
 	for (guint i = 0; i < self->pos; i++)
-		xb_opcode_unref (self->opcodes[i]);
+		xb_opcode_clear (&self->opcodes[i]);
 	g_free (self);
 }
 
@@ -61,33 +61,38 @@ xb_stack_ref (XbStack *self)
 /**
  * xb_stack_pop:
  * @self: a #XbStack
+ * @opcode_out: (out caller-allocates) (optional): return location for the popped #XbOpcode
  *
  * Pops an opcode off the stack.
  *
- * Returns: (transfer full): a #XbOpcode
+ * Returns: %TRUE if popping succeeded, %FALSE if the stack was empty already
  *
- * Since: 0.1.3
+ * Since: 0.2.0
  **/
-XbOpcode *
-xb_stack_pop (XbStack *self)
+gboolean
+xb_stack_pop (XbStack *self, XbOpcode *opcode_out)
 {
 	if (self->pos == 0)
-		return NULL;
-	return self->opcodes[--self->pos];
+		return FALSE;
+	self->pos--;
+	if (opcode_out != NULL)
+		*opcode_out = self->opcodes[self->pos];
+	return TRUE;
 }
 
 /* private */
-GPtrArray *
+GArray *
 xb_stack_steal_all (XbStack *self)
 {
-	GPtrArray *array;
+	g_autoptr(GArray) array = NULL;
 
 	/* array takes ownership of the opcodes */
-	array = g_ptr_array_new_with_free_func ((GDestroyNotify) xb_opcode_unref);
-	for (guint i = 0; i < self->pos; i++)
-		g_ptr_array_add (array, self->opcodes[i]);
+	array = g_array_new (FALSE, FALSE, sizeof (XbOpcode));
+	g_array_set_clear_func (array, (GDestroyNotify) xb_opcode_clear);
+	g_array_append_vals (array, self->opcodes, self->pos);
 	self->pos = 0;
-	return array;
+
+	return g_steal_pointer (&array);
 }
 
 /**
@@ -106,14 +111,18 @@ xb_stack_peek (XbStack *self, guint idx)
 {
 	if (idx >= self->pos)
 		return NULL;
-	return self->opcodes[idx];
+	return &self->opcodes[idx];
 }
 
 /* private */
 gboolean
 xb_stack_push_bool (XbStack *self, gboolean val)
 {
-	return xb_stack_push_steal (self, xb_opcode_bool_new (val));
+	XbOpcode *op;
+	if (!xb_stack_push (self, &op))
+		return FALSE;
+	xb_opcode_bool_init (op, val);
+	return TRUE;
 }
 
 /* private */
@@ -122,7 +131,7 @@ xb_stack_peek_head (XbStack *self)
 {
 	if (self->pos == 0)
 		return NULL;
-	return self->opcodes[0];
+	return &self->opcodes[0];
 }
 
 /* private */
@@ -131,26 +140,33 @@ xb_stack_peek_tail (XbStack *self)
 {
 	if (self->pos == 0)
 		return NULL;
-	return self->opcodes[self->pos - 1];
+	return &self->opcodes[self->pos - 1];
 }
 
 /**
  * xb_stack_push:
  * @self: a #XbStack
- * @opcode: a #XbOpcode
+ * @opcode_out: (out) (nullable): return location for the new #XbOpcode
  *
- * Pushes a new opcode onto the end of the stack
+ * Pushes a new empty opcode onto the end of the stack. A pointer to the opcode
+ * is returned in @opcode_out so that the caller can initialise it. This must be
+ * done before the stack is next used as, for performance reasons, the newly
+ * pushed opcode is not zero-initialised.
  *
- * Returns: %TRUE if the opcode was stored on the stack
- *
- * Since: 0.1.3
+ * Returns: %TRUE if a new empty opcode was returned, or %FALSE if the stack has
+ *    reached its maximum size
+ * Since: 0.2.0
  **/
 gboolean
-xb_stack_push (XbStack *self, XbOpcode *opcode)
+xb_stack_push (XbStack *self,
+	       XbOpcode **opcode_out)
 {
-	if (self->pos >= self->max_size)
+	if (self->pos >= self->max_size) {
+		*opcode_out = NULL;
 		return FALSE;
-	self->opcodes[self->pos++] = xb_opcode_ref (opcode);
+	}
+
+	*opcode_out = &self->opcodes[self->pos++];
 	return TRUE;
 }
 
@@ -164,14 +180,12 @@ xb_stack_push (XbStack *self, XbOpcode *opcode)
  * Returns: %TRUE if the opcode was stored on the stack
  *
  * Since: 0.1.3
+ * Deprecated: 0.2.0: Use xb_stack_push() instead
  **/
 gboolean
 xb_stack_push_steal (XbStack *self, XbOpcode *opcode)
 {
-	if (self->pos >= self->max_size)
-		return FALSE;
-	self->opcodes[self->pos++] = opcode;
-	return TRUE;
+	g_assert_not_reached ();
 }
 
 /**
@@ -221,7 +235,7 @@ xb_stack_to_string (XbStack *self)
 {
 	GString *str = g_string_new (NULL);
 	for (guint i = 0; i < self->pos; i++) {
-		g_autofree gchar *tmp = xb_opcode_to_string (self->opcodes[i]);
+		g_autofree gchar *tmp = xb_opcode_to_string (&self->opcodes[i]);
 		g_string_append_printf (str, "%s,", tmp);
 	}
 	if (str->len > 0)
@@ -243,7 +257,7 @@ xb_stack_to_string (XbStack *self)
 XbStack *
 xb_stack_new (guint max_size)
 {
-	XbStack *self = g_malloc0 (sizeof(XbStack) + max_size * sizeof(XbOpcode*));
+	XbStack *self = g_malloc0 (sizeof(XbStack) + max_size * sizeof(XbOpcode));
 	self->ref = 1;
 	self->max_size = max_size;
 	return self;

--- a/src/xb-stack.h
+++ b/src/xb-stack.h
@@ -16,10 +16,12 @@ typedef struct _XbStack XbStack;
 
 GType		 xb_stack_get_type		(void);
 gchar		*xb_stack_to_string		(XbStack	*self);
-XbOpcode	*xb_stack_pop			(XbStack	*self);
+gboolean	 xb_stack_pop			(XbStack	*self,
+						 XbOpcode	*opcode_out);
 gboolean	 xb_stack_push			(XbStack	*self,
-						 XbOpcode	*opcode);
+						 XbOpcode	**opcode_out);
+G_DEPRECATED_FOR(xb_stack_push)
 gboolean	 xb_stack_push_steal		(XbStack	*self,
-						 XbOpcode	*opcode);
+						 XbOpcode	*opcode) G_GNUC_NORETURN;
 
 G_END_DECLS


### PR DESCRIPTION
On a simple test of loading gnome-software and switching between a
couple of categories, this reduces calls to `g_slice_new0()` from around
21 million to around 5 million.

Signed-off-by: Philip Withnall <withnall@endlessm.com>