### PR TITLE
Do not allocate opcodes individually

### DIFF
--- a/contrib/libxmlb.spec.in
+++ b/contrib/libxmlb.spec.in
@@ -24,10 +24,6 @@ BuildRequires: python-setuptools
 # needed for the self tests
 BuildRequires: shared-mime-info
 
-%if 0%{?rhel} < 8
-BuildRequires: python34
-%endif
-
 Requires: glib2%{?_isa} >= %{glib2_version}
 Requires: shared-mime-info
 
@@ -77,7 +73,7 @@ Executable and data files for installed tests.
 %{_libexecdir}/xb-tool
 %dir %{_libdir}/girepository-1.0
 %{_libdir}/girepository-1.0/*.typelib
-%{_libdir}/libxmlb.so.1*
+%{_libdir}/libxmlb.so.2*
 
 %files devel
 %dir %{_datadir}/gir-1.0

--- a/docs/libxmlb.types
+++ b/docs/libxmlb.types
@@ -1,7 +1,6 @@
 xb_silo_get_type
 xb_machine_get_type
 xb_node_get_type
-xb_opcode_get_type
 xb_stack_get_type
 xb_builder_get_type
 xb_builder_fixup_get_type

--- a/meson.build
+++ b/meson.build
@@ -18,7 +18,7 @@ conf.set('XMLB_MICRO_VERSION', libxmlb_micro_version)
 conf.set_quoted('PACKAGE_VERSION', libxmlb_version)
 
 # libtool versioning - this applies to libxmlb
-lt_current = '1'
+lt_current = '2'
 lt_revision = '0'
 lt_age = '0'
 lt_version = '@0@.@1@.@2@'.format(lt_current, lt_age, lt_revision)
@@ -27,7 +27,7 @@ configinc = include_directories('.')
 
 # get suported warning flags
 warning_flags = [
-  '-Waggregate-return',
+  '-Wno-aggregate-return',
   '-Wunused',
   '-Warray-bounds',
   '-Wcast-align',

--- a/src/libxmlb.map
+++ b/src/libxmlb.map
@@ -89,33 +89,11 @@ LIBXMLB_0.1.1 {
     xb_machine_add_text_handler;
     xb_machine_get_type;
     xb_machine_new;
-    xb_machine_opcode_func_new;
-    xb_machine_opcode_to_string;
-    xb_machine_opcodes_to_string;
     xb_machine_parse;
     xb_machine_run;
     xb_machine_set_debug_flags;
-    xb_machine_stack_pop;
-    xb_machine_stack_push;
-    xb_machine_stack_push_integer;
-    xb_machine_stack_push_text;
-    xb_machine_stack_push_text_static;
-    xb_machine_stack_push_text_steal;
-    xb_opcode_cmp_str;
-    xb_opcode_cmp_val;
-    xb_opcode_func_new;
-    xb_opcode_get_kind;
-    xb_opcode_get_str;
-    xb_opcode_get_type;
-    xb_opcode_get_val;
-    xb_opcode_integer_new;
     xb_opcode_kind_from_string;
     xb_opcode_kind_to_string;
-    xb_opcode_ref;
-    xb_opcode_text_new;
-    xb_opcode_text_new_static;
-    xb_opcode_text_new_steal;
-    xb_opcode_unref;
     xb_silo_get_profile_string;
     xb_silo_invalidate;
     xb_silo_set_profile_flags;
@@ -144,19 +122,13 @@ LIBXMLB_0.1.3 {
     xb_builder_source_add_fixup;
     xb_machine_get_stack_size;
     xb_machine_set_stack_size;
-    xb_stack_get_type;
-    xb_stack_pop;
-    xb_stack_push;
-    xb_stack_push_steal;
   local: *;
 } LIBXMLB_0.1.2;
 
 LIBXMLB_0.1.4 {
   global:
     xb_machine_parse_full;
-    xb_machine_stack_push_steal;
     xb_node_query_full;
-    xb_opcode_to_string;
     xb_query_bind_str;
     xb_query_bind_val;
     xb_query_get_limit;
@@ -165,6 +137,7 @@ LIBXMLB_0.1.4 {
     xb_query_new;
     xb_query_set_limit;
     xb_silo_query_build_index;
+    xb_stack_get_type;
     xb_stack_to_string;
   local: *;
 } LIBXMLB_0.1.3;
@@ -222,3 +195,17 @@ LIBXMLB_0.1.15 {
     xb_query_set_flags;
   local: *;
 } LIBXMLB_0.1.13;
+
+LIBXMLB_0.2.0 {
+  global:
+    xb_machine_opcode_func_init;
+    xb_machine_stack_pop;
+    xb_machine_stack_push;
+    xb_machine_stack_push_integer;
+    xb_machine_stack_push_text;
+    xb_machine_stack_push_text_static;
+    xb_machine_stack_push_text_steal;
+    xb_stack_pop;
+    xb_stack_push;
+  local: *;
+} LIBXMLB_0.1.15;

--- a/src/xb-machine.h
+++ b/src/xb-machine.h
@@ -115,35 +115,33 @@ void		 xb_machine_add_operator	(XbMachine		*self,
 						 const gchar		*str,
 						 const gchar		*name);
 
-XbOpcode	*xb_machine_opcode_func_new	(XbMachine		*self,
+gboolean	 xb_machine_opcode_func_init	(XbMachine		*self,
+						 XbOpcode		*opcode,
 						 const gchar		*func_name);
-gchar		*xb_machine_opcode_to_string	(XbMachine		*self,
-						 XbOpcode		*opcode)
-G_DEPRECATED_FOR(xb_opcode_to_string);
-gchar		*xb_machine_opcodes_to_string	(XbMachine		*self,
-						 XbStack		*opcodes)
-G_DEPRECATED_FOR(xb_stack_to_string);
 
-XbOpcode	*xb_machine_stack_pop		(XbMachine		*self,
-						 XbStack		*stack);
-void		 xb_machine_stack_push		(XbMachine		*self,
+gboolean	 xb_machine_stack_pop		(XbMachine		*self,
 						 XbStack		*stack,
-						 XbOpcode		*opcode);
-void		 xb_machine_stack_push_steal	(XbMachine		*self,
+						 XbOpcode		*opcode_out);
+gboolean	 xb_machine_stack_push		(XbMachine		*self,
 						 XbStack		*stack,
-						 XbOpcode		*opcode);
-void		 xb_machine_stack_push_text	(XbMachine		*self,
+						 XbOpcode		**opcode_out,
+						 GError			**error);
+gboolean	 xb_machine_stack_push_text	(XbMachine		*self,
 						 XbStack		*stack,
-						 const gchar		*str);
-void		 xb_machine_stack_push_text_static (XbMachine		*self,
+						 const gchar		*str,
+						 GError			**error);
+gboolean	 xb_machine_stack_push_text_static (XbMachine		*self,
 						 XbStack		*stack,
-						 const gchar		*str);
-void		 xb_machine_stack_push_text_steal (XbMachine		*self,
+						 const gchar		*str,
+						 GError			**error);
+gboolean	 xb_machine_stack_push_text_steal (XbMachine		*self,
 						 XbStack		*stack,
-						 gchar			*str);
-void		 xb_machine_stack_push_integer	(XbMachine		*self,
+						 gchar			*str,
+						 GError			**error);
+gboolean	 xb_machine_stack_push_integer	(XbMachine		*self,
 						 XbStack		*stack,
-						 guint32		 val);
+						 guint32		 val,
+						 GError			**error);
 void		 xb_machine_set_stack_size	(XbMachine		*self,
 						 guint			 stack_size);
 guint		 xb_machine_get_stack_size	(XbMachine		*self);

--- a/src/xb-opcode-private.h
+++ b/src/xb-opcode-private.h
@@ -10,11 +10,40 @@
 
 G_BEGIN_DECLS
 
-XbOpcode	*xb_opcode_new			(XbOpcodeKind	 kind,
+struct _XbOpcode {
+	XbOpcodeKind	 kind;
+	guint32		 val;
+	gpointer	 ptr;
+	GDestroyNotify	 destroy_func;
+};
+
+#define XB_OPCODE_INIT() { 0, 0, NULL, NULL }
+
+/**
+ * xb_opcode_steal:
+ * @op_ptr: (transfer full): pointer to an #XbOpcode to steal
+ *
+ * Steal the stack-allocated #XbOpcode pointed to by @op_ptr, returning its
+ * value and clearing its previous storage location using `memset()`.
+ *
+ * Returns: the value of @op_ptr
+ * Since: 0.2.0
+ */
+static inline XbOpcode
+xb_opcode_steal (XbOpcode *op_ptr)
+{
+	XbOpcode op = *op_ptr;
+	memset (op_ptr, 0, sizeof (XbOpcode));
+	return op;
+}
+
+void		 xb_opcode_init			(XbOpcode	*opcode,
+						 XbOpcodeKind	 kind,
 						 const gchar	*str,
 						 guint32	 val,
 						 GDestroyNotify	 destroy_func);
-XbOpcode	*xb_opcode_bind_new		(void);
+void		 xb_opcode_clear		(XbOpcode	*opcode);
+void		 xb_opcode_bind_init		(XbOpcode	*opcode);
 gboolean	 xb_opcode_is_bound		(XbOpcode	*self);
 void		 xb_opcode_bind_str		(XbOpcode	*self,
 						 gchar		*str,
@@ -26,6 +55,9 @@ void		 xb_opcode_set_kind		(XbOpcode	*self,
 void		 xb_opcode_set_val		(XbOpcode	*self,
 						 guint32	 val);
 gchar		*xb_opcode_get_sig		(XbOpcode	*self);
-XbOpcode	*xb_opcode_bool_new		(gboolean	 val);
+void		 xb_opcode_bool_init		(XbOpcode	*opcode,
+						 gboolean	 val);
+
+G_DEFINE_AUTO_CLEANUP_CLEAR_FUNC (XbOpcode, xb_opcode_clear)
 
 G_END_DECLS

--- a/src/xb-opcode.h
+++ b/src/xb-opcode.h
@@ -67,24 +67,23 @@ typedef struct _XbOpcode XbOpcode;
 gboolean	 xb_opcode_cmp_val		(XbOpcode	*self);
 gboolean	 xb_opcode_cmp_str		(XbOpcode	*self);
 
-GType		 xb_opcode_get_type		(void);
 gchar		*xb_opcode_to_string		(XbOpcode	*self);
 const gchar	*xb_opcode_kind_to_string	(XbOpcodeKind	 kind);
 XbOpcodeKind	 xb_opcode_kind_from_string	(const gchar	*str);
-
-void		 xb_opcode_unref		(XbOpcode	*self);
-XbOpcode	*xb_opcode_ref			(XbOpcode	*self);
 
 XbOpcodeKind	 xb_opcode_get_kind		(XbOpcode	*self);
 const gchar	*xb_opcode_get_str		(XbOpcode	*self);
 guint32		 xb_opcode_get_val		(XbOpcode	*self);
 
-XbOpcode	*xb_opcode_func_new		(guint32	 func);
-XbOpcode	*xb_opcode_integer_new		(guint32	 val);
-XbOpcode	*xb_opcode_text_new		(const gchar	*str);
-XbOpcode	*xb_opcode_text_new_static	(const gchar	*str);
-XbOpcode	*xb_opcode_text_new_steal	(gchar		*str);
-
-G_DEFINE_AUTOPTR_CLEANUP_FUNC(XbOpcode, xb_opcode_unref)
+void		 xb_opcode_func_init		(XbOpcode	*opcode,
+						 guint32	 func);
+void		 xb_opcode_integer_init		(XbOpcode	*opcode,
+						 guint32	 val);
+void		 xb_opcode_text_init		(XbOpcode	*opcode,
+						 const gchar	*str);
+void		 xb_opcode_text_init_static	(XbOpcode	*opcode,
+						 const gchar	*str);
+void		 xb_opcode_text_init_steal	(XbOpcode	*opcode,
+						 gchar		*str);
 
 G_END_DECLS

--- a/src/xb-stack-private.h
+++ b/src/xb-stack-private.h
@@ -23,7 +23,6 @@ XbOpcode	*xb_stack_peek			(XbStack	*self,
 						 guint		 idx);
 XbOpcode	*xb_stack_peek_head		(XbStack	*self);
 XbOpcode	*xb_stack_peek_tail		(XbStack	*self);
-GPtrArray	*xb_stack_steal_all		(XbStack	*self);
 
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(XbStack, xb_stack_unref)
 

--- a/src/xb-stack.h
+++ b/src/xb-stack.h
@@ -16,10 +16,9 @@ typedef struct _XbStack XbStack;
 
 GType		 xb_stack_get_type		(void);
 gchar		*xb_stack_to_string		(XbStack	*self);
-XbOpcode	*xb_stack_pop			(XbStack	*self);
+gboolean	 xb_stack_pop			(XbStack	*self,
+						 XbOpcode	*opcode_out);
 gboolean	 xb_stack_push			(XbStack	*self,
-						 XbOpcode	*opcode);
-gboolean	 xb_stack_push_steal		(XbStack	*self,
-						 XbOpcode	*opcode);
+						 XbOpcode	**opcode_out);
 
 G_END_DECLS


### PR DESCRIPTION
On a simple test of loading gnome-software and switching between a couple of
categories, this reduces calls to `g_slice_new0()` from around 21 million to
around 5 million.

It reduces the time to show (refine) the ‘Games’ category from around 9s to
around 5s the first time it’s shown (in a very unrigorous test).

This makes `XbOpcode` stack-only, and removes all API which requires it to be
heap-allocated. For the most part, this only requires mechanical changes in the
rest of the codebase to operate on stack-allocated opcodes, removing one layer
of indirection in some places.

The largest other change needed was to rewrite the optimiser to avoid using
`GArray`, as tracking the ownership of `XbOpcode`s through several different
`GArray`s was getting too complex. The new implementation of the optimiser
works as before, except it only uses one helper stack rather than a helper
stack and two temporary arrays. This brings its own inherent performance
benefits, as around 5 million XPath queries are done when gnome-software starts
up, so making the optimiser run quickly is important.

This ABI breaks API and ABI, and thus also bumps soname.

Signed-off-by: Philip Withnall <withnall@endlessm.com>