### PR TITLE
Do not show a critical warning for invalid XML

### DIFF
--- a/src/xb-builder-node.c
+++ b/src/xb-builder-node.c
@@ -751,6 +751,10 @@ xb_builder_node_set_priority (XbBuilderNode *self, gint priority)
 	XbBuilderNodePrivate *priv = GET_PRIVATE (self);
 	g_return_if_fail (XB_IS_BUILDER_NODE (self));
 	priv->priority = priority;
+	for (guint i = 0; i < priv->children->len; i++) {
+		XbBuilderNode *c = g_ptr_array_index (priv->children, i);
+		xb_builder_node_set_priority (c, priority);
+	}
 }
 
 /* private */


### PR DESCRIPTION
If we ignore a node due to XB_BUILDER_COMPILE_FLAG_SINGLE_LANG then also ignore
the child nodes. This ensures we do not warn when presented with something like:

    <description xml:lang=de>
      <ul><li xml:lang=de></li><li></li></ul>
    </description>
    <description>
      <ul><li></li></ul>
    </description>

Fixes https://github.com/hughsie/libxmlb/issues/50