### PR TITLE
xb-builder-source-ctx: Store a GFile for the source too

### DIFF
--- a/src/xb-builder-source-ctx-private.h
+++ b/src/xb-builder-source-ctx-private.h
@@ -12,7 +12,8 @@
 
 G_BEGIN_DECLS
 
-XbBuilderSourceCtx *xb_builder_source_ctx_new		(GInputStream		*istream);
+XbBuilderSourceCtx *xb_builder_source_ctx_new		(GFile			*file,
+							 GInputStream		*istream);
 void		 xb_builder_source_ctx_set_filename	(XbBuilderSourceCtx	*self,
 							 const gchar		*filename);
 gchar		*xb_builder_source_ctx_get_content_type	(XbBuilderSourceCtx	*self,

--- a/src/xb-builder-source-ctx.c
+++ b/src/xb-builder-source-ctx.c
@@ -85,7 +85,7 @@ _g_input_stream_read_bytes_in_chunks (GInputStream *stream,
  *
  * Returns the data currently being processed.
  *
- * Returns: (transfer none): a #GInputStream
+ * Returns: (transfer full): a #GBytes
  *
  * Since: 0.1.7
  **/
@@ -110,7 +110,7 @@ xb_builder_source_ctx_get_bytes (XbBuilderSourceCtx *self,
  *
  * Returns the basename of the file currently being processed.
  *
- * Returns: a basename, or %NULL if unset
+ * Returns: (transfer none) (nullable): a basename, or %NULL if unset
  *
  * Since: 0.1.7
  **/
@@ -125,11 +125,13 @@ xb_builder_source_ctx_get_filename (XbBuilderSourceCtx *self)
 /**
  * xb_builder_source_ctx_get_content_type:
  * @self: a #XbBuilderSourceCtx
+ * @cancellable: a #GCancellable, or %NULL
+ * @error: the #GError, or %NULL
  *
  * Returns the content type of the input stream currently being
  * processed.
  *
- * Returns: (transfer full): a content type (e.g. `application/x-desktop`), or %NULL
+ * Returns: (transfer full): a content type (e.g. `application/x-desktop`), or %NULL on error
  *
  * Since: 0.1.7
  **/
@@ -192,7 +194,7 @@ xb_builder_source_ctx_class_init (XbBuilderSourceCtxClass *klass)
 
 /**
  * xb_builder_source_ctx_new:
- * @element: An element name, e.g. "component"
+ * @istream: (transfer none): Input stream to load the source from
  *
  * Creates a new builder source_ctx.
  *

--- a/src/xb-builder-source-ctx.c
+++ b/src/xb-builder-source-ctx.c
@@ -14,6 +14,7 @@
 #include "xb-common-private.h"
 
 typedef struct {
+	GFile			*file;
 	GInputStream		*istream;
 	gchar			*basename;
 	gchar			*content_type;
@@ -182,6 +183,7 @@ xb_builder_source_ctx_finalize (GObject *obj)
 	XbBuilderSourceCtxPrivate *priv = GET_PRIVATE (self);
 	g_free (priv->basename);
 	g_object_unref (priv->istream);
+	g_clear_object (&priv->file);
 	G_OBJECT_CLASS (xb_builder_source_ctx_parent_class)->finalize (obj);
 }
 
@@ -194,6 +196,8 @@ xb_builder_source_ctx_class_init (XbBuilderSourceCtxClass *klass)
 
 /**
  * xb_builder_source_ctx_new:
+ * @file: (transfer none) (nullable): Path to the file which contains the source,
+ *    or %NULL if the source is not directly loadable from disk
  * @istream: (transfer none): Input stream to load the source from
  *
  * Creates a new builder source_ctx.
@@ -203,10 +207,15 @@ xb_builder_source_ctx_class_init (XbBuilderSourceCtxClass *klass)
  * Since: 0.1.7
  **/
 XbBuilderSourceCtx *
-xb_builder_source_ctx_new (GInputStream *istream)
+xb_builder_source_ctx_new (GFile *file, GInputStream *istream)
 {
 	XbBuilderSourceCtx *self = g_object_new (XB_TYPE_BUILDER_SOURCE_CTX, NULL);
 	XbBuilderSourceCtxPrivate *priv = GET_PRIVATE (self);
+
+	g_return_val_if_fail (file == NULL || G_IS_FILE (file), NULL);
+	g_return_val_if_fail (G_IS_INPUT_STREAM (istream), NULL);
+
+	priv->file = (file != NULL) ? g_object_ref (file) : NULL;
 	priv->istream = g_object_ref (istream);
 	return self;
 }

--- a/src/xb-builder-source-ctx.c
+++ b/src/xb-builder-source-ctx.c
@@ -15,7 +15,7 @@
 
 typedef struct {
 	GInputStream		*istream;
-	gchar			*filename;
+	gchar			*basename;
 	gchar			*content_type;
 } XbBuilderSourceCtxPrivate;
 
@@ -110,7 +110,7 @@ xb_builder_source_ctx_get_bytes (XbBuilderSourceCtx *self,
  *
  * Returns the basename of the file currently being processed.
  *
- * Returns: a filename, or %NULL if unset
+ * Returns: a basename, or %NULL if unset
  *
  * Since: 0.1.7
  **/
@@ -119,7 +119,7 @@ xb_builder_source_ctx_get_filename (XbBuilderSourceCtx *self)
 {
 	XbBuilderSourceCtxPrivate *priv = GET_PRIVATE (self);
 	g_return_val_if_fail (XB_IS_BUILDER_SOURCE_CTX (self), NULL);
-	return priv->filename;
+	return priv->basename;
 }
 
 /**
@@ -153,19 +153,19 @@ xb_builder_source_ctx_get_content_type (XbBuilderSourceCtx *self,
 			return NULL;
 	}
 	if (bufsz > 0)
-		return xb_content_type_guess (priv->filename, buf, bufsz);
-	return xb_content_type_guess (priv->filename, NULL, 0);
+		return xb_content_type_guess (priv->basename, buf, bufsz);
+	return xb_content_type_guess (priv->basename, NULL, 0);
 }
 
 /* private */
 void
-xb_builder_source_ctx_set_filename (XbBuilderSourceCtx *self, const gchar *filename)
+xb_builder_source_ctx_set_filename (XbBuilderSourceCtx *self, const gchar *basename)
 {
 	XbBuilderSourceCtxPrivate *priv = GET_PRIVATE (self);
 	g_return_if_fail (XB_IS_BUILDER_SOURCE_CTX (self));
-	g_return_if_fail (filename != NULL);
-	g_free (priv->filename);
-	priv->filename = g_strdup (filename);
+	g_return_if_fail (basename != NULL);
+	g_free (priv->basename);
+	priv->basename = g_strdup (basename);
 }
 
 static void
@@ -178,7 +178,7 @@ xb_builder_source_ctx_finalize (GObject *obj)
 {
 	XbBuilderSourceCtx *self = XB_BUILDER_SOURCE_CTX (obj);
 	XbBuilderSourceCtxPrivate *priv = GET_PRIVATE (self);
-	g_free (priv->filename);
+	g_free (priv->basename);
 	g_object_unref (priv->istream);
 	G_OBJECT_CLASS (xb_builder_source_ctx_parent_class)->finalize (obj);
 }


### PR DESCRIPTION
As well as an input stream for reading the source, store a `GFile`
pointing to the on-disk file which backs the source, if possible.

This allows callers to load the source data directly from disk, which
may be more efficient than streaming it in, and will almost certainly be
more efficient than allocating a 128MB GBytes buffer and reading it all
at once. For example, a caller could memory map moderately sized files.

This adds new API, and breaks some internal API.

Signed-off-by: Philip Withnall <withnall@endlessm.com>