### PR TITLE
xb: Drop redundant parent_instance members from GObject private structs

### DIFF
--- a/src/xb-builder-fixup.c
+++ b/src/xb-builder-fixup.c
@@ -13,7 +13,6 @@
 #include "xb-builder-fixup-private.h"
 
 typedef struct {
-	GObject			 parent_instance;
 	gchar			*id;
 	XbBuilderFixupFunc	 func;
 	gpointer		 user_data;

--- a/src/xb-builder-node.c
+++ b/src/xb-builder-node.c
@@ -16,7 +16,6 @@
 #include "xb-string-private.h"
 
 typedef struct {
-	GObject			 parent_instance;
 	guint32			 offset;
 	gint			 priority;
 	XbBuilderNodeFlags	 flags;

--- a/src/xb-builder-source-ctx.c
+++ b/src/xb-builder-source-ctx.c
@@ -13,7 +13,6 @@
 #include "xb-builder-source-ctx-private.h"
 
 typedef struct {
-	GObject			 parent_instance;
 	GInputStream		*istream;
 	gchar			*filename;
 	gchar			*content_type;

--- a/src/xb-builder-source.c
+++ b/src/xb-builder-source.c
@@ -16,7 +16,6 @@
 #include "xb-builder-source-private.h"
 
 typedef struct {
-	GObject			 parent_instance;
 	GInputStream		*istream;
 	GFile			*file;
 	GPtrArray		*fixups;	/* of XbBuilderFixup */

--- a/src/xb-builder.c
+++ b/src/xb-builder.c
@@ -19,7 +19,6 @@
 #include "xb-builder-node-private.h"
 
 typedef struct {
-	GObject			 parent_instance;
 	GPtrArray		*sources;	/* of XbBuilderSource */
 	GPtrArray		*nodes;		/* of XbBuilderNode */
 	GPtrArray		*fixups;	/* of XbBuilderFixup */

--- a/src/xb-machine.c
+++ b/src/xb-machine.c
@@ -22,7 +22,6 @@
 #include "xb-string-private.h"
 
 typedef struct {
-	GObject			 parent_instance;
 	XbMachineDebugFlags	 debug_flags;
 	GPtrArray		*methods;	/* of XbMachineMethodItem */
 	GPtrArray		*operators;	/* of XbMachineOperator */

--- a/src/xb-node.c
+++ b/src/xb-node.c
@@ -15,7 +15,6 @@
 #include "xb-silo-export-private.h"
 
 typedef struct {
-	GObject			 parent_instance;
 	XbSilo			*silo;
 	XbSiloNode		*sn;
 } XbNodePrivate;

--- a/src/xb-query.c
+++ b/src/xb-query.c
@@ -17,7 +17,6 @@
 #include "xb-stack-private.h"
 
 typedef struct {
-	GObject			 parent_instance;
 	GPtrArray		*sections;		/* of XbQuerySection */
 	XbSilo			*silo;
 	XbQueryFlags		 flags;

--- a/src/xb-silo.c
+++ b/src/xb-silo.c
@@ -24,7 +24,6 @@
 #include "xb-string-private.h"
 
 typedef struct {
-	GObject			 parent_instance;
 	GMappedFile		*mmap;
 	gchar			*guid;
 	gboolean		 valid;


### PR DESCRIPTION
The `parent_instance` member is only needed when creating a derived
`GObject` without a separate private data struct (for example, when
using `G_DECLARE_FINAL_TYPE`).

When using `G_DEFINE_TYPE_WITH_PRIVATE` the `MyTypePrivate` struct only
needs to contain the private members, no boilerplate.

This saves around 500KB of memory in the `XbNode`s created by the silo
when opening gnome-software.

Signed-off-by: Philip Withnall <withnall@endlessm.com>