### PR TITLE
Allow monitoring directories as builder sources

### DIFF
--- a/src/xb-builder-source.h
+++ b/src/xb-builder-source.h
@@ -35,6 +35,9 @@ struct _XbBuilderSourceClass {
  * @XB_BUILDER_SOURCE_FLAG_NONE:		No extra flags to use
  * @XB_BUILDER_SOURCE_FLAG_LITERAL_TEXT:	Do not attempt to repair XML whitespace
  * @XB_BUILDER_SOURCE_FLAG_WATCH_FILE:		Watch the source file for changes
+ * @XB_BUILDER_SOURCE_FLAG_WATCH_DIRECTORY:	Watch the directory containing the source file for changes
+ * 	(for example, if watching all the sources in a directory — this allows the
+ * 	file monitors to be shared)
  *
  * The flags for converting to XML.
  **/
@@ -42,6 +45,7 @@ typedef enum {
 	XB_BUILDER_SOURCE_FLAG_NONE		= 0,		/* Since: 0.1.0 */
 	XB_BUILDER_SOURCE_FLAG_LITERAL_TEXT	= 1 << 0,	/* Since: 0.1.0 */
 	XB_BUILDER_SOURCE_FLAG_WATCH_FILE	= 1 << 1,	/* Since: 0.1.0 */
+	XB_BUILDER_SOURCE_FLAG_WATCH_DIRECTORY	= 1 << 2,	/* Since: 0.2.0 */
 	/*< private >*/
 	XB_BUILDER_SOURCE_FLAG_LAST
 } XbBuilderSourceFlags;

--- a/src/xb-builder.c
+++ b/src/xb-builder.c
@@ -648,11 +648,18 @@ xb_builder_watch_source (XbBuilder *self,
 {
 	XbBuilderPrivate *priv = GET_PRIVATE (self);
 	GFile *file = xb_builder_source_get_file (source);
+	g_autoptr(GFile) watched_file = NULL;
 	if (file == NULL)
 		return TRUE;
-	if ((xb_builder_source_get_flags (source) & XB_BUILDER_SOURCE_FLAG_WATCH_FILE) == 0)
+	if ((xb_builder_source_get_flags (source) & (XB_BUILDER_SOURCE_FLAG_WATCH_FILE | XB_BUILDER_SOURCE_FLAG_WATCH_DIRECTORY)) == 0)
 		return TRUE;
-	if (!xb_silo_watch_file (priv->silo, file, cancellable, error))
+
+	if (xb_builder_source_get_flags (source) & XB_BUILDER_SOURCE_FLAG_WATCH_DIRECTORY)
+		watched_file = g_file_get_parent (file);
+	else
+		watched_file = g_object_ref (file);
+
+	if (!xb_silo_watch_file (priv->silo, watched_file, cancellable, error))
 		return FALSE;
 	return TRUE;
 }

--- a/src/xb-silo.c
+++ b/src/xb-silo.c
@@ -776,8 +776,8 @@ xb_silo_watch_file (XbSilo *self,
 		return TRUE;
 
 	/* try to create */
-	file_monitor = g_file_monitor_file (file, G_FILE_MONITOR_NONE,
-					    cancellable, error);
+	file_monitor = g_file_monitor (file, G_FILE_MONITOR_NONE,
+				       cancellable, error);
 	if (file_monitor == NULL)
 		return FALSE;
 	g_file_monitor_set_rate_limit (file_monitor, 20);


### PR DESCRIPTION
See the commit messages.

tl;dr: This reduces the number of file monitors in gnome-software by an order of magnitude.