### PR TITLE
Conditionally drop XbSilo node cache

### DIFF
--- a/src/libxmlb.map
+++ b/src/libxmlb.map
@@ -203,6 +203,8 @@ LIBXMLB_0.2.0 {
     xb_machine_stack_push_text;
     xb_machine_stack_push_text_static;
     xb_machine_stack_push_text_steal;
+    xb_silo_get_enable_node_cache;
+    xb_silo_set_enable_node_cache;
     xb_stack_pop;
     xb_stack_push;
   local: *;

--- a/src/xb-builder.c
+++ b/src/xb-builder.c
@@ -718,6 +718,9 @@ xb_builder_compile (XbBuilder *self, XbBuilderCompileFlags flags, GCancellable *
 	if (flags & XB_BUILDER_COMPILE_FLAG_SINGLE_LANG)
 		flags |= XB_BUILDER_COMPILE_FLAG_NATIVE_LANGS;
 
+	/* disable the silo cache of all the XbNodes */
+	xb_silo_set_enable_node_cache (priv->silo, (flags & XB_BUILDER_COMPILE_FLAG_NO_NODE_CACHE) == 0);
+
 	/* the builder needs to know the locales */
 	if (priv->locales->len == 0 && (flags & XB_BUILDER_COMPILE_FLAG_NATIVE_LANGS)) {
 		g_set_error_literal (error,
@@ -894,6 +897,9 @@ xb_builder_ensure (XbBuilder *self, GFile *file, XbBuilderCompileFlags flags,
 	/* profile new silo if needed */
 	xb_silo_set_profile_flags (silo_tmp, priv->profile_flags);
 
+	/* no need for the node cache */
+	xb_silo_set_enable_node_cache (silo_tmp, FALSE);
+
 	/* load the file and peek at the GUIDs */
 	fn = g_file_get_path (file);
 	g_debug ("attempting to load %s", fn);
@@ -920,6 +926,9 @@ xb_builder_ensure (XbBuilder *self, GFile *file, XbBuilderCompileFlags flags,
 		if (g_strcmp0 (xb_silo_get_guid (silo_tmp), guid) == 0 ||
 		    (flags & XB_BUILDER_COMPILE_FLAG_IGNORE_GUID) > 0) {
 			g_autoptr(GBytes) blob = xb_silo_get_bytes (silo_tmp);
+
+			xb_silo_set_enable_node_cache (priv->silo, (flags & XB_BUILDER_COMPILE_FLAG_NO_NODE_CACHE) == 0);
+
 			g_debug ("loading silo with file contents");
 			if (!xb_silo_load_from_bytes (priv->silo, blob,
 						      load_flags, error))

--- a/src/xb-builder.h
+++ b/src/xb-builder.h
@@ -39,6 +39,7 @@ struct _XbBuilderClass {
  * @XB_BUILDER_COMPILE_FLAG_SINGLE_LANG:	Only store a single language
  * @XB_BUILDER_COMPILE_FLAG_WATCH_BLOB:		Watch the XMLB file for changes
  * @XB_BUILDER_COMPILE_FLAG_IGNORE_GUID:	Ignore the cache GUID value
+ * @XB_BUILDER_COMPILE_FLAG_NO_NODE_CACHE:	Don’t cache #XbNode instances in #XbSilo indefinitely
  *
  * The flags for converting to XML.
  **/
@@ -49,6 +50,7 @@ typedef enum {
 	XB_BUILDER_COMPILE_FLAG_SINGLE_LANG	= 1 << 3,	/* Since: 0.1.0 */
 	XB_BUILDER_COMPILE_FLAG_WATCH_BLOB	= 1 << 4,	/* Since: 0.1.0 */
 	XB_BUILDER_COMPILE_FLAG_IGNORE_GUID	= 1 << 5,	/* Since: 0.1.7 */
+	XB_BUILDER_COMPILE_FLAG_NO_NODE_CACHE	= 1 << 6,	/* Since: 0.2.0 */
 	/*< private >*/
 	XB_BUILDER_COMPILE_FLAG_LAST
 } XbBuilderCompileFlags;

--- a/src/xb-node.c
+++ b/src/xb-node.c
@@ -29,6 +29,11 @@ G_DEFINE_TYPE_WITH_PRIVATE (XbNode, xb_node, G_TYPE_OBJECT)
  *
  * Gets any data that has been set on the node using xb_node_set_data().
  *
+ * This will only work across queries to the associated silo if the silo has
+ * its #XbSilo:enable-node-cache property set to %TRUE. Otherwise a new #XbNode
+ * may be constructed for future queries which return the same element as a
+ * result.
+ *
  * Returns: (transfer none): a #GBytes, or %NULL if not found
  *
  * Since: 0.1.0
@@ -36,8 +41,10 @@ G_DEFINE_TYPE_WITH_PRIVATE (XbNode, xb_node, G_TYPE_OBJECT)
 GBytes *
 xb_node_get_data (XbNode *self, const gchar *key)
 {
+	XbNodePrivate *priv = GET_PRIVATE (self);
 	g_return_val_if_fail (XB_IS_NODE (self), NULL);
 	g_return_val_if_fail (key != NULL, NULL);
+	g_return_val_if_fail (priv->silo, NULL);
 	return g_object_get_data (G_OBJECT (self), key);
 }
 
@@ -49,14 +56,21 @@ xb_node_get_data (XbNode *self, const gchar *key)
  *
  * Sets some data on the node which can be retrieved using xb_node_get_data().
  *
+ * This will only work across queries to the associated silo if the silo has
+ * its #XbSilo:enable-node-cache property set to %TRUE. Otherwise a new #XbNode
+ * may be constructed for future queries which return the same element as a
+ * result.
+ *
  * Since: 0.1.0
  **/
 void
 xb_node_set_data (XbNode *self, const gchar *key, GBytes *data)
 {
+	XbNodePrivate *priv = GET_PRIVATE (self);
 	g_return_if_fail (XB_IS_NODE (self));
 	g_return_if_fail (key != NULL);
 	g_return_if_fail (data != NULL);
+	g_return_if_fail (priv->silo);
 	g_object_set_data_full (G_OBJECT (self), key,
 				g_bytes_ref (data),
 				(GDestroyNotify) g_bytes_unref);

--- a/src/xb-node.c
+++ b/src/xb-node.c
@@ -386,7 +386,7 @@ xb_node_export (XbNode *self, XbNodeExportFlags flags, GError **error)
 	GString *xml;
 	g_return_val_if_fail (XB_IS_NODE (self), NULL);
 	g_return_val_if_fail (error == NULL || *error == NULL, NULL);
-	xml = xb_silo_export_with_root (xb_node_get_silo (self), self, flags, error);
+	xml = xb_silo_export_with_root (xb_node_get_silo (self), xb_node_get_sn (self), flags, error);
 	if (xml == NULL)
 		return NULL;
 	return g_string_free (xml, FALSE);

--- a/src/xb-silo-export-private.h
+++ b/src/xb-silo-export-private.h
@@ -11,7 +11,7 @@
 G_BEGIN_DECLS
 
 GString		*xb_silo_export_with_root	(XbSilo		*self,
-						 XbNode		*root,
+						 XbSiloNode	*sroot,
 						 XbNodeExportFlags flags,
 						 GError		**error);
 

--- a/src/xb-silo-export.c
+++ b/src/xb-silo-export.c
@@ -101,7 +101,7 @@ xb_silo_export_node (XbSilo *self, XbSiloExportHelper *helper, XbSiloNode *sn, G
 
 /* private */
 GString *
-xb_silo_export_with_root (XbSilo *self, XbNode *root, XbNodeExportFlags flags, GError **error)
+xb_silo_export_with_root (XbSilo *self, XbSiloNode *sroot, XbNodeExportFlags flags, GError **error)
 {
 	XbSiloNode *sn;
 	XbSiloExportHelper helper = {
@@ -117,8 +117,8 @@ xb_silo_export_with_root (XbSilo *self, XbNode *root, XbNodeExportFlags flags, G
 		flags |= XB_NODE_EXPORT_FLAG_INCLUDE_SIBLINGS;
 
 	/* optional subtree export */
-	if (root != NULL) {
-		sn = xb_node_get_sn (root);
+	if (sroot != NULL) {
+		sn = sroot;
 		if (sn != NULL && flags & XB_NODE_EXPORT_FLAG_ONLY_CHILDREN)
 			sn = xb_silo_node_get_child (self, sn);
 	} else {

--- a/src/xb-silo-query-private.h
+++ b/src/xb-silo-query-private.h
@@ -13,6 +13,11 @@
 
 G_BEGIN_DECLS
 
+GPtrArray	*xb_silo_query_sn_with_root	(XbSilo		*self,
+						 XbNode		*n,
+						 const gchar	*xpath,
+						 guint		 limit,
+						 GError		**error);
 GPtrArray	*xb_silo_query_with_root	(XbSilo		*self,
 						 XbNode		*n,
 						 const gchar	*xpath,

--- a/src/xb-silo.h
+++ b/src/xb-silo.h
@@ -93,4 +93,8 @@ void		 xb_silo_set_profile_flags		(XbSilo		*self,
 							 XbSiloProfileFlags profile_flags);
 const gchar	*xb_silo_get_profile_string		(XbSilo		*self);
 
+gboolean	 xb_silo_get_enable_node_cache		(XbSilo		*self);
+void		 xb_silo_set_enable_node_cache		(XbSilo		*self,
+							 gboolean	 enable_node_cache);
+
 G_END_DECLS


### PR DESCRIPTION
See the commit messages for reasoning.

tl;dr: This drops 1.8MB of heap memory of `XbNode`s which are used a few times and then never used again, but hang around in the silo’s cache for the lifetime of gnome-software.