### PR TITLE
xb-builder-node: Don’t crash if priv->children is NULL

### DIFF
--- a/src/xb-builder-node.c
+++ b/src/xb-builder-node.c
@@ -785,7 +785,7 @@ xb_builder_node_set_priority (XbBuilderNode *self, gint priority)
 	XbBuilderNodePrivate *priv = GET_PRIVATE (self);
 	g_return_if_fail (XB_IS_BUILDER_NODE (self));
 	priv->priority = priority;
-	for (guint i = 0; i < priv->children->len; i++) {
+	for (guint i = 0; priv->children != NULL && i < priv->children->len; i++) {
 		XbBuilderNode *c = g_ptr_array_index (priv->children, i);
 		xb_builder_node_set_priority (c, priority);
 	}


### PR DESCRIPTION
Since commit d12765d0, `priv->children` is loaded lazily, and can be
`NULL`. Commit b7f2509c2b3 (#50) introduced a crash in that case.

Signed-off-by: Philip Withnall <withnall@endlessm.com>