### PR TITLE
xb-silo: Don’t unconditionally create GTimer objects

### DIFF
--- a/src/xb-builder.c
+++ b/src/xb-builder.c
@@ -220,7 +220,7 @@ xb_builder_compile_source (XbBuilderCompileHelper *helper,
 	g_autoptr(GPtrArray) children_copy = NULL;
 	g_autoptr(GInputStream) istream = NULL;
 	g_autoptr(GMarkupParseContext) ctx = NULL;
-	g_autoptr(GTimer) timer = g_timer_new ();
+	g_autoptr(GTimer) timer = xb_silo_start_profile (helper->silo);
 	g_autoptr(XbBuilderNode) root_tmp = xb_builder_node_new (NULL);
 	const GMarkupParser parser = {
 		xb_builder_compile_start_element_cb,
@@ -707,7 +707,7 @@ xb_builder_compile (XbBuilder *self, XbBuilderCompileFlags flags, GCancellable *
 		.buf = NULL,
 	};
 	g_autoptr(GPtrArray) nodes_to_destroy = g_ptr_array_new ();
-	g_autoptr(GTimer) timer = g_timer_new ();
+	g_autoptr(GTimer) timer = xb_silo_start_profile (priv->silo);
 	g_autoptr(XbBuilderCompileHelper) helper = NULL;
 
 	g_return_val_if_fail (XB_IS_BUILDER (self), NULL);

--- a/src/xb-silo-private.h
+++ b/src/xb-silo-private.h
@@ -87,6 +87,7 @@ guint		 xb_silo_node_get_depth		(XbSilo		*self,
 						 XbSiloNode	*n);
 XbNode		*xb_silo_node_create		(XbSilo		*self,
 						 XbSiloNode	*sn);
+GTimer		*xb_silo_start_profile		(XbSilo		*self);
 void		 xb_silo_add_profile		(XbSilo		*self,
 						 GTimer		*timer,
 						 const gchar	*fmt,

--- a/src/xb-silo-query.c
+++ b/src/xb-silo-query.c
@@ -211,7 +211,7 @@ silo_query_with_root (XbSilo *self, XbNode *n, const gchar *xpath, guint limit, 
 	g_auto(GStrv) split = NULL;
 	g_autoptr(GHashTable) results_hash = g_hash_table_new (g_direct_hash, g_direct_equal);
 	g_autoptr(GPtrArray) results = NULL;
-	g_autoptr(GTimer) timer = g_timer_new ();
+	g_autoptr(GTimer) timer = xb_silo_start_profile (self);
 	XbSiloQueryData query_data = {
 		.sn = NULL,
 		.position = 0,
@@ -381,7 +381,7 @@ xb_silo_query_with_root_full (XbSilo *self, XbNode *n, XbQuery *query, GError **
 	XbSiloNode *sn = NULL;
 	g_autoptr(GHashTable) results_hash = g_hash_table_new (g_direct_hash, g_direct_equal);
 	g_autoptr(GPtrArray) results = g_ptr_array_new_with_free_func ((GDestroyNotify) g_object_unref);
-	g_autoptr(GTimer) timer = g_timer_new ();
+	g_autoptr(GTimer) timer = xb_silo_start_profile (self);
 	XbSiloQueryData query_data = {
 		.sn = NULL,
 		.position = 0,

--- a/src/xb-silo.c
+++ b/src/xb-silo.c
@@ -63,16 +63,32 @@ enum {
 };
 
 /* private */
+GTimer *
+xb_silo_start_profile (XbSilo *self)
+{
+	XbSiloPrivate *priv = GET_PRIVATE (self);
+
+	/* nothing to do; g_timer_new() does a syscall to clock_gettime() which
+	 * is best avoided if not needed */
+	if (!priv->profile_flags)
+		return NULL;
+
+	return g_timer_new ();
+}
+
+/* private */
 void
 xb_silo_add_profile (XbSilo *self, GTimer *timer, const gchar *fmt, ...)
 {
 	XbSiloPrivate *priv = GET_PRIVATE (self);
 	va_list args;
-	g_autoptr(GString) str = g_string_new (NULL);
+	g_autoptr(GString) str = NULL;
 
 	/* nothing to do */
 	if (!priv->profile_flags)
 		return;
+
+	str = g_string_new ("");
 
 	/* add duration */
 	if (timer != NULL) {
@@ -596,7 +612,7 @@ xb_silo_load_from_bytes (XbSilo *self, GBytes *blob, XbSiloLoadFlags flags, GErr
 	gsize sz = 0;
 	guint32 off = 0;
 	g_autoptr(GMutexLocker) locker = NULL;
-	g_autoptr(GTimer) timer = g_timer_new ();
+	g_autoptr(GTimer) timer = xb_silo_start_profile (self);
 
 	g_return_val_if_fail (XB_IS_SILO (self), FALSE);
 	g_return_val_if_fail (blob != NULL, FALSE);
@@ -870,7 +886,7 @@ xb_silo_load_from_file (XbSilo *self,
 	XbSiloPrivate *priv = GET_PRIVATE (self);
 	g_autofree gchar *fn = NULL;
 	g_autoptr(GBytes) blob = NULL;
-	g_autoptr(GTimer) timer = g_timer_new ();
+	g_autoptr(GTimer) timer = xb_silo_start_profile (self);
 
 	g_return_val_if_fail (XB_IS_SILO (self), FALSE);
 	g_return_val_if_fail (G_IS_FILE (file), FALSE);
@@ -924,7 +940,7 @@ xb_silo_save_to_file (XbSilo *self,
 {
 	XbSiloPrivate *priv = GET_PRIVATE (self);
 	g_autoptr(GFile) file_parent = NULL;
-	g_autoptr(GTimer) timer = g_timer_new ();
+	g_autoptr(GTimer) timer = xb_silo_start_profile (self);
 
 	g_return_val_if_fail (XB_IS_SILO (self), FALSE);
 	g_return_val_if_fail (G_IS_FILE (file), FALSE);


### PR DESCRIPTION
Most of the time, profiling is disabled, and these are unnecessary. Each
call to `g_timer_new()` calls the `clock_gettime()` syscall, which is
not particularly cheap.

This reduces `clock_gettime()` calls by around 11000 while starting up
gnome-software.

Signed-off-by: Philip Withnall <withnall@endlessm.com>