### PR TITLE
Fix a parse failure for a double comment

### DIFF
--- a/src/xb-builder.c
+++ b/src/xb-builder.c
@@ -170,14 +170,9 @@ xb_builder_compile_text_cb (GMarkupParseContext *context,
 		xb_builder_node_set_tail (bc, text, text_len);
 		return;
 	}
-	if (!xb_builder_node_has_flag (bn, XB_BUILDER_NODE_FLAG_HAS_TAIL)) {
-		xb_builder_node_set_tail (bn, text, text_len);
-		return;
-	}
-	g_set_error (error,
-		     G_IO_ERROR,
-		     G_IO_ERROR_INVALID_DATA,
-		     "Mismatched XML; cannot store %s", text);
+
+	/* always set a tail, even if already set */
+	xb_builder_node_set_tail (bn, text, text_len);
 }
 
 /**

--- a/src/xb-self-test.c
+++ b/src/xb-self-test.c
@@ -1513,6 +1513,35 @@ xb_builder_native_lang_func (void)
 }
 
 static void
+xb_builder_comments_func (void)
+{
+	gboolean ret;
+	g_autoptr(GError) error = NULL;
+	g_autofree gchar *str = NULL;
+	g_autoptr(XbBuilder) builder = xb_builder_new ();
+	g_autoptr(XbSilo) silo = NULL;
+	const gchar *xml =
+	"<?xml version=\"1.0\" ?>\n"
+	"<components>\n"
+	"  <!-- one -->\n"
+	"  <!-- two -->\n"
+	"</components>\n";
+
+	/* import XML */
+	ret = xb_test_import_xml (builder, xml, &error);
+	g_assert_no_error (error);
+	g_assert_true (ret);
+	silo = xb_builder_compile (builder, XB_BUILDER_COMPILE_FLAG_NONE, NULL, &error);
+	g_assert_no_error (error);
+	g_assert_nonnull (silo);
+
+	/* export */
+	str = xb_silo_export (silo, XB_NODE_EXPORT_FLAG_NONE, &error);
+	g_assert_no_error (error);
+	g_assert_cmpstr (str, ==, "<components></components>");
+}
+
+static void
 xb_builder_native_lang2_func (void)
 {
 	gboolean ret;
@@ -2432,6 +2461,7 @@ main (int argc, char **argv)
 	g_test_add_func ("/libxmlb/stack{peek}", xb_stack_peek_func);
 	g_test_add_func ("/libxmlb/node{data}", xb_node_data_func);
 	g_test_add_func ("/libxmlb/builder", xb_builder_func);
+	g_test_add_func ("/libxmlb/builder{comments}", xb_builder_comments_func);
 	g_test_add_func ("/libxmlb/builder{native-lang}", xb_builder_native_lang_func);
 	g_test_add_func ("/libxmlb/builder{native-lang-nested}", xb_builder_native_lang2_func);
 	g_test_add_func ("/libxmlb/builder{native-lang-locale}", xb_builder_native_lang_no_locales_func);


### PR DESCRIPTION
We don't handle GMarkupParser->passthrough and so in the double-comment case we
can call GMarkupParser->text on the same builder node more than once. As it's
typically just a (another!) newline, just store the 'last set' tail rather than
trying to append them together.

Fixes https://github.com/hughsie/libxmlb/issues/70