### PR TITLE
Allow collapsing empty XML tags if no children or text

### DIFF
--- a/src/xb-node.h
+++ b/src/xb-node.h
@@ -33,6 +33,7 @@ struct _XbNodeClass {
  * @XB_NODE_EXPORT_FLAG_FORMAT_INDENT:		Indent the XML by child depth
  * @XB_NODE_EXPORT_FLAG_INCLUDE_SIBLINGS:	Include the siblings when converting
  * @XB_NODE_EXPORT_FLAG_ONLY_CHILDREN:		Only export the children of the node
+ * @XB_NODE_EXPORT_FLAG_COLLAPSE_EMPTY:		If node has no children, collapse open and close tags
  *
  * The flags for converting to XML.
  **/
@@ -43,6 +44,7 @@ typedef enum {
 	XB_NODE_EXPORT_FLAG_FORMAT_INDENT	= 1 << 2,	/* Since: 0.1.0 */
 	XB_NODE_EXPORT_FLAG_INCLUDE_SIBLINGS	= 1 << 3,	/* Since: 0.1.0 */
 	XB_NODE_EXPORT_FLAG_ONLY_CHILDREN	= 1 << 4,	/* Since: 0.1.0 */
+	XB_NODE_EXPORT_FLAG_COLLAPSE_EMPTY	= 1 << 5,	/* Since: 0.2.2 */
 	/*< private >*/
 	XB_NODE_EXPORT_FLAG_LAST
 } XbNodeExportFlags;

--- a/src/xb-self-test.c
+++ b/src/xb-self-test.c
@@ -1014,6 +1014,39 @@ xb_node_data_func (void)
 }
 
 static void
+xb_node_export_func (void)
+{
+	g_autoptr(GError) error = NULL;
+	g_autoptr(XbNode) n = NULL;
+	g_autoptr(XbSilo) silo = NULL;
+	g_autoptr(GBytes) bytes = g_bytes_new ("foo", 4);
+	g_autofree gchar *xml_default = NULL;
+	g_autofree gchar *xml_collapsed = NULL;
+
+	/* import from XML */
+	silo = xb_silo_new_from_xml ("<component attr1=\"val1\" attr2=\"val2\"/>", &error);
+	g_assert_no_error (error);
+	g_assert_nonnull (silo);
+
+	/* get node */
+	n = xb_silo_query_first (silo, "component", &error);
+	g_assert_no_error (error);
+	g_assert_nonnull (n);
+
+	/* export default */
+	xml_default = xb_node_export (n, XB_NODE_EXPORT_FLAG_NONE, &error);
+	g_assert_no_error (error);
+	g_assert_nonnull (xml_default);
+	g_assert_cmpstr (xml_default, ==, "<component attr1=\"val1\" attr2=\"val2\"></component>");
+
+	/* export collapsed */
+	xml_collapsed = xb_node_export (n, XB_NODE_EXPORT_FLAG_COLLAPSE_EMPTY, &error);
+	g_assert_no_error (error);
+	g_assert_nonnull (xml_collapsed);
+	g_assert_cmpstr (xml_collapsed, ==, "<component attr1=\"val1\" attr2=\"val2\" />");
+}
+
+static void
 xb_xpath_parent_subnode_func (void)
 {
 	g_autofree gchar *xml2 = NULL;
@@ -2460,6 +2493,7 @@ main (int argc, char **argv)
 	g_test_add_func ("/libxmlb/stack", xb_stack_func);
 	g_test_add_func ("/libxmlb/stack{peek}", xb_stack_peek_func);
 	g_test_add_func ("/libxmlb/node{data}", xb_node_data_func);
+	g_test_add_func ("/libxmlb/node{export}", xb_node_export_func);
 	g_test_add_func ("/libxmlb/builder", xb_builder_func);
 	g_test_add_func ("/libxmlb/builder{comments}", xb_builder_comments_func);
 	g_test_add_func ("/libxmlb/builder{native-lang}", xb_builder_native_lang_func);


### PR DESCRIPTION
Add a new COLLAPSE_IF_NO_CHILDREN flag to allow requesting collapsed
open/close tags (e.g. <collapsed/>) when exporting the XML.