### PR TITLE
xb-silo: Don’t use GRWLockReaderLocker yet

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -120,6 +120,12 @@ if giounix.found()
   conf.set('HAVE_GIO_UNIX', '1')
 endif
 
+# Limit our use of GLib API to our minimum version requirement, and what’s
+# available in Debian Stable. Use of more modern API has to be optional and
+# protected by GLIB_CHECK_VERSION.
+add_project_arguments('-DGLIB_VERSION_MIN_REQUIRED=GLIB_VERSION_2_46', language: 'c')
+add_project_arguments('-DGLIB_VERSION_MAX_ALLOWED=GLIB_VERSION_2_58', language: 'c')
+
 libxmlb_deps = [
   gio,
 ]


### PR DESCRIPTION
It was only introduced in GLib 2.62, which isn’t available on (for
example) Debian Stable. Use the `g_rw_lock_*()` methods directly
instead. There’s no point in using `GRWLockReaderLocker` if the GLib
version is high enough, as the amount of macro boilerplate needed would
be relatively high.

This fixes building gnome-software (transitively) on Debian Stable.

Signed-off-by: Philip Withnall <pwithnall@endlessos.org>