### PR TITLE
xb-query-context: Only use G_ALIGNOF if GLib is new enough

### DIFF
--- a/src/xb-query-context.c
+++ b/src/xb-query-context.c
@@ -33,7 +33,9 @@ typedef struct {
 } RealQueryContext;
 
 G_STATIC_ASSERT (sizeof (XbQueryContext) == sizeof (RealQueryContext));
+#if GLIB_CHECK_VERSION(2, 60, 0)
 G_STATIC_ASSERT (G_ALIGNOF (XbQueryContext) == G_ALIGNOF (RealQueryContext));
+#endif
 
 G_DEFINE_BOXED_TYPE (XbQueryContext, xb_query_context,
 		     xb_query_context_copy, xb_query_context_free)

--- a/src/xb-value-bindings.c
+++ b/src/xb-value-bindings.c
@@ -38,7 +38,9 @@ typedef struct {
 } RealValueBindings;
 
 G_STATIC_ASSERT (sizeof (XbValueBindings) == sizeof (RealValueBindings));
+#if GLIB_CHECK_VERSION(2, 60, 0)
 G_STATIC_ASSERT (G_ALIGNOF (XbValueBindings) == G_ALIGNOF (RealValueBindings));
+#endif
 
 G_DEFINE_BOXED_TYPE (XbValueBindings, xb_value_bindings,
 		     xb_value_bindings_copy, xb_value_bindings_free)


### PR DESCRIPTION
Unfortunately it’s not protected by `GLIB_VERSION_MAX_ALLOWED` because
we couldn’t get that working for macros in public headers in GLib.

Signed-off-by: Philip Withnall <pwithnall@endlessos.org>