### PR TITLE
Improve performance of XbStack

### DIFF
--- a/src/xb-machine.c
+++ b/src/xb-machine.c
@@ -636,7 +636,7 @@ static gboolean
 xb_machine_opcodes_optimize (XbMachine *self, XbStack *opcodes, GError **error)
 {
 	XbMachinePrivate *priv = GET_PRIVATE (self);
-	g_autoptr(XbStack) results = xb_stack_new (xb_stack_get_size (opcodes));
+	g_autoptr(XbStack) results = xb_stack_new_inline (xb_stack_get_size (opcodes));
 	g_auto(XbOpcode) op = XB_OPCODE_INIT ();
 
 	/* debug */
@@ -967,7 +967,7 @@ xb_machine_run_with_bindings (XbMachine        *self,
 	g_return_val_if_fail (error == NULL || *error == NULL, FALSE);
 
 	/* process each opcode */
-	stack = xb_stack_new (priv->stack_size);
+	stack = xb_stack_new_inline (priv->stack_size);
 	for (guint i = 0; i < opcodes_stack_size; i++) {
 		XbOpcode *opcode = xb_stack_peek (opcodes, i);
 		XbOpcodeKind kind = xb_opcode_get_kind (opcode);

--- a/src/xb-opcode.c
+++ b/src/xb-opcode.c
@@ -140,7 +140,10 @@ xb_opcode_to_string (XbOpcode *self)
 {
 	g_autofree gchar *tmp = xb_opcode_to_string_internal (self);
 	if (self->kind & XB_OPCODE_FLAG_TOKENIZED) {
-		g_autofree gchar *tokens = g_strjoinv (",", (gchar **) self->tokens);
+		g_autofree gchar *tokens = NULL;
+		/* Ensure the array is NULL-terminated */
+		self->tokens[self->tokens_len] = NULL;
+		tokens = g_strjoinv (",", (gchar **) self->tokens);
 		return g_strdup_printf ("%s[%s]", tmp, tokens);
 	}
 	return g_steal_pointer (&tmp);
@@ -340,6 +343,7 @@ xb_opcode_init (XbOpcode       *opcode,
 	opcode->kind = kind;
 	opcode->ptr = (gpointer) str;
 	opcode->val = val;
+	opcode->tokens_len = 0;
 	opcode->destroy_func = destroy_func;
 }
 

--- a/src/xb-stack.c
+++ b/src/xb-stack.c
@@ -13,13 +13,6 @@
 #include "xb-opcode-private.h"
 #include "xb-stack-private.h"
 
-struct _XbStack {
-	gint		 ref;
-	guint		 pos;	/* index of the next unused entry in .opcodes */
-	guint		 max_size;
-	XbOpcode	 opcodes[];	/* allocated as part of XbStack */
-};
-
 /**
  * xb_stack_unref:
  * @self: a #XbStack
@@ -37,7 +30,8 @@ xb_stack_unref (XbStack *self)
 		return;
 	for (guint i = 0; i < self->pos; i++)
 		xb_opcode_clear (&self->opcodes[i]);
-	g_free (self);
+	if (!self->stack_allocated)
+		g_free (self);
 }
 
 /**
@@ -254,6 +248,8 @@ xb_stack_to_string (XbStack *self)
  * Creates a stack for the XbMachine request. Only #XbOpcode's can be pushed and
  * popped from the stack.
  *
+ * Unlike with xb_stack_new_inline(), this stack will be allocated on the heap.
+ *
  * Returns: (transfer full): a #XbStack
  *
  * Since: 0.1.3
@@ -263,6 +259,7 @@ xb_stack_new (guint max_size)
 {
 	XbStack *self = g_malloc (sizeof(XbStack) + max_size * sizeof(XbOpcode));
 	self->ref = 1;
+	self->stack_allocated = FALSE;
 	self->pos = 0;
 	self->max_size = max_size;
 	return self;

--- a/src/xb-stack.c
+++ b/src/xb-stack.c
@@ -261,8 +261,9 @@ xb_stack_to_string (XbStack *self)
 XbStack *
 xb_stack_new (guint max_size)
 {
-	XbStack *self = g_malloc0 (sizeof(XbStack) + max_size * sizeof(XbOpcode));
+	XbStack *self = g_malloc (sizeof(XbStack) + max_size * sizeof(XbOpcode));
 	self->ref = 1;
+	self->pos = 0;
 	self->max_size = max_size;
 	return self;
 }


### PR DESCRIPTION
Avoid heap-allocating it when it’s being used to run an `XbMachine`, as that happens 3 million times when starting gnome-software.

This reduces the time it takes to show the main window of gnome-software by 0.1s (from 1.1s to 1.0s). It reduces the number of `memset()` calls measured by callgrind from 27.4 million to 4.8 million.

No public API changes, so this should be OK to backport to stable distros if desired.