### PR TITLE
trivial: Fix a warning when used in a subproject

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -98,8 +98,7 @@ xb_tool = executable(
 )
 
 pkgg = import('pkgconfig')
-pkgg.generate(
-  libraries : libxmlb,
+pkgg.generate(libxmlb,
   requires : [ 'gio-2.0' ],
   subdirs : 'libxmlb-2',
   version : meson.project_version(),


### PR DESCRIPTION
Fixes:

DEPRECATION: Library xmlb was passed to the libraries keyword argument of a
previous call to generate() method instead of first positional argument.