### PR TITLE
Fix GMainContext issues with silo signals and file monitoring

### DIFF
--- a/src/xb-builder.c
+++ b/src/xb-builder.c
@@ -905,6 +905,9 @@ xb_builder_compile (XbBuilder *self, XbBuilderCompileFlags flags, GCancellable *
  * If @silo is being used by a query (e.g. in another thread) then all node
  * data is immediately invalid.
  *
+ * The returned #XbSilo will use the thread-default main context at the time of
+ * calling this function for its future signal emissions.
+ *
  * Returns: (transfer full): a #XbSilo, or %NULL for error
  *
  * Since: 0.1.0
@@ -1098,6 +1101,10 @@ xb_builder_init (XbBuilder *self)
  * xb_builder_new:
  *
  * Creates a new builder.
+ *
+ * The #XbSilo returned by the methods of this #XbBuilder will use the
+ * thread-default main context at the time of calling this function for its
+ * future signal emissions.
  *
  * Returns: a new #XbBuilder
  *

--- a/src/xb-silo.c
+++ b/src/xb-silo.c
@@ -1565,7 +1565,7 @@ xb_silo_class_init (XbSiloClass *klass)
 				     G_PARAM_STATIC_NAME);
 
 	/**
-	 * XbSilo:allow-cancel:
+	 * XbSilo:valid:
 	 */
 	obj_props[PROP_VALID] =
 		g_param_spec_boolean ("valid", NULL, NULL, TRUE,

--- a/src/xb-silo.c
+++ b/src/xb-silo.c
@@ -58,13 +58,13 @@ typedef struct {
 G_DEFINE_TYPE_WITH_PRIVATE (XbSilo, xb_silo, G_TYPE_OBJECT)
 #define GET_PRIVATE(o) (xb_silo_get_instance_private (o))
 
-enum {
-	PROP_0,
-	PROP_GUID,
+typedef enum {
+	PROP_GUID = 1,
 	PROP_VALID,
 	PROP_ENABLE_NODE_CACHE,
-	PROP_LAST
-};
+} XbSiloProperty;
+
+static GParamSpec *obj_props[PROP_ENABLE_NODE_CACHE + 1] = { NULL, };
 
 /* private */
 GTimer *
@@ -1431,7 +1431,7 @@ xb_silo_get_property (GObject *obj, guint prop_id, GValue *value, GParamSpec *ps
 {
 	XbSilo *self = XB_SILO (obj);
 	XbSiloPrivate *priv = GET_PRIVATE (self);
-	switch (prop_id) {
+	switch ((XbSiloProperty) prop_id) {
 	case PROP_GUID:
 		g_value_set_string (value, priv->guid);
 		break;
@@ -1452,10 +1452,14 @@ xb_silo_set_property (GObject *obj, guint prop_id, const GValue *value, GParamSp
 {
 	XbSilo *self = XB_SILO (obj);
 	XbSiloPrivate *priv = GET_PRIVATE (self);
-	switch (prop_id) {
+	switch ((XbSiloProperty) prop_id) {
 	case PROP_GUID:
 		g_free (priv->guid);
 		priv->guid = g_value_dup_string (value);
+		break;
+	case PROP_VALID:
+		/* Read only */
+		g_assert_not_reached ();
 		break;
 	case PROP_ENABLE_NODE_CACHE:
 		xb_silo_set_enable_node_cache (self, g_value_get_boolean (value));
@@ -1546,7 +1550,6 @@ xb_silo_finalize (GObject *obj)
 static void
 xb_silo_class_init (XbSiloClass *klass)
 {
-	GParamSpec *pspec;
 	GObjectClass *object_class = G_OBJECT_CLASS (klass);
 	object_class->finalize = xb_silo_finalize;
 	object_class->get_property = xb_silo_get_property;
@@ -1555,19 +1558,19 @@ xb_silo_class_init (XbSiloClass *klass)
 	/**
 	 * XbSilo:guid:
 	 */
-	pspec = g_param_spec_string ("guid", NULL, NULL, NULL,
+	obj_props[PROP_GUID] =
+		g_param_spec_string ("guid", NULL, NULL, NULL,
 				     G_PARAM_READWRITE |
 				     G_PARAM_CONSTRUCT |
 				     G_PARAM_STATIC_NAME);
-	g_object_class_install_property (object_class, PROP_GUID, pspec);
 
 	/**
 	 * XbSilo:allow-cancel:
 	 */
-	pspec = g_param_spec_boolean ("valid", NULL, NULL, TRUE,
+	obj_props[PROP_VALID] =
+		g_param_spec_boolean ("valid", NULL, NULL, TRUE,
 				      G_PARAM_READABLE |
 				      G_PARAM_STATIC_NAME);
-	g_object_class_install_property (object_class, PROP_VALID, pspec);
 
 	/**
 	 * XbSilo:enable-node-cache:
@@ -1590,10 +1593,12 @@ xb_silo_class_init (XbSiloClass *klass)
 	 *
 	 * Since: 0.2.0
 	 */
-	pspec = g_param_spec_boolean ("enable-node-cache", NULL, NULL, TRUE,
+	obj_props[PROP_ENABLE_NODE_CACHE] =
+		g_param_spec_boolean ("enable-node-cache", NULL, NULL, TRUE,
 				      G_PARAM_READWRITE |
 				      G_PARAM_STATIC_NAME);
-	g_object_class_install_property (object_class, PROP_ENABLE_NODE_CACHE, pspec);
+
+	g_object_class_install_properties (object_class, G_N_ELEMENTS (obj_props), obj_props);
 }
 
 /**

--- a/src/xb-silo.c
+++ b/src/xb-silo.c
@@ -1562,7 +1562,7 @@ xb_silo_class_init (XbSiloClass *klass)
 		g_param_spec_string ("guid", NULL, NULL, NULL,
 				     G_PARAM_READWRITE |
 				     G_PARAM_CONSTRUCT |
-				     G_PARAM_STATIC_NAME);
+				     G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * XbSilo:valid:
@@ -1570,7 +1570,7 @@ xb_silo_class_init (XbSiloClass *klass)
 	obj_props[PROP_VALID] =
 		g_param_spec_boolean ("valid", NULL, NULL, TRUE,
 				      G_PARAM_READABLE |
-				      G_PARAM_STATIC_NAME);
+				      G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * XbSilo:enable-node-cache:
@@ -1596,7 +1596,7 @@ xb_silo_class_init (XbSiloClass *klass)
 	obj_props[PROP_ENABLE_NODE_CACHE] =
 		g_param_spec_boolean ("enable-node-cache", NULL, NULL, TRUE,
 				      G_PARAM_READWRITE |
-				      G_PARAM_STATIC_NAME);
+				      G_PARAM_STATIC_STRINGS);
 
 	g_object_class_install_properties (object_class, G_N_ELEMENTS (obj_props), obj_props);
 }


### PR DESCRIPTION
See the commit messages for details.

This is not required to fix the immediate issue in gnome-software (a workaround was committed in https://gitlab.gnome.org/GNOME/gnome-software/-/issues/1422), but does tidy things up and make the behaviour more consistent.

Code which uses libxmlb should check what `GMainContext` is the thread default when calling `xb_builder_new()`, `xb_silo_new()`, `xb_builder_ensure()`, `xb_builder_compile()` or `xb_silo_watch_file()`.