### PR TITLE
Use -Dcli=false to reduce the install size

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -2,3 +2,4 @@ option('gtkdoc', type : 'boolean', value : true, description : 'enable developer
 option('introspection', type : 'boolean', value : true, description : 'generate GObject Introspection data')
 option('tests', type : 'boolean', value : true, description : 'enable tests')
 option('stemmer', type : 'boolean', value : false, description : 'enable stemmer support')
+option('cli', type : 'boolean', value : true, description : 'build and install the xb-tool CLI')

--- a/src/meson.build
+++ b/src/meson.build
@@ -80,6 +80,7 @@ libxmlb_dep = declare_dependency(
   dependencies : libxmlb_deps
 )
 
+if get_option('cli')
 xb_tool = executable(
   'xb-tool',
   sources : [
@@ -97,6 +98,7 @@ xb_tool = executable(
   install : true,
   install_dir : libexecdir
 )
+endif
 
 pkgg = import('pkgconfig')
 pkgg.generate(libxmlb,


### PR DESCRIPTION
We don't need or want this debugging tool on embedded targets.