### PR TITLE
Add a flag to require the XbBuilderSource to have no siblings

### DIFF
--- a/src/xb-builder.c
+++ b/src/xb-builder.c
@@ -260,6 +260,17 @@ xb_builder_compile_source (XbBuilderCompileHelper *helper,
 	if (!xb_builder_source_fixup (source, root_tmp, error))
 		return FALSE;
 
+	/* a single root with no siblings was required */
+	if (helper->compile_flags & XB_BUILDER_COMPILE_FLAG_SINGLE_ROOT) {
+		if (xb_builder_node_get_children (root_tmp)->len > 1) {
+			g_set_error_literal (error,
+					     G_IO_ERROR,
+					     G_IO_ERROR_INVALID_DATA,
+					     "A root node without siblings was required");
+			return FALSE;
+		}
+	}
+
 	/* this is something we can query with later */
 	info = xb_builder_source_get_info (source);
 	if (info != NULL) {

--- a/src/xb-builder.h
+++ b/src/xb-builder.h
@@ -39,6 +39,7 @@ struct _XbBuilderClass {
  * @XB_BUILDER_COMPILE_FLAG_SINGLE_LANG:	Only store a single language
  * @XB_BUILDER_COMPILE_FLAG_WATCH_BLOB:		Watch the XMLB file for changes
  * @XB_BUILDER_COMPILE_FLAG_IGNORE_GUID:	Ignore the cache GUID value
+ * @XB_BUILDER_COMPILE_FLAG_SINGLE_ROOT:	Require at most one root node
  *
  * The flags for converting to XML.
  **/
@@ -49,6 +50,7 @@ typedef enum {
 	XB_BUILDER_COMPILE_FLAG_SINGLE_LANG	= 1 << 3,	/* Since: 0.1.0 */
 	XB_BUILDER_COMPILE_FLAG_WATCH_BLOB	= 1 << 4,	/* Since: 0.1.0 */
 	XB_BUILDER_COMPILE_FLAG_IGNORE_GUID	= 1 << 5,	/* Since: 0.1.7 */
+	XB_BUILDER_COMPILE_FLAG_SINGLE_ROOT	= 1 << 6,	/* Since: 0.3.4 */
 	/*< private >*/
 	XB_BUILDER_COMPILE_FLAG_LAST
 } XbBuilderCompileFlags;

--- a/src/xb-self-test.c
+++ b/src/xb-self-test.c
@@ -2044,6 +2044,24 @@ xb_builder_multiple_roots_func (void)
 }
 
 static void
+xb_builder_single_root_func (void)
+{
+	gboolean ret;
+	g_autoptr(GError) error = NULL;
+	g_autoptr(XbBuilder) builder = NULL;
+	g_autoptr(XbSilo) silo = NULL;
+
+	/* import from XML */
+	builder = xb_builder_new ();
+	ret = xb_test_import_xml (builder, "<tag>value2</tag><tag>value3</tag>", &error);
+	g_assert_no_error (error);
+	g_assert_true (ret);
+	silo = xb_builder_compile (builder, XB_BUILDER_COMPILE_FLAG_SINGLE_ROOT, NULL, &error);
+	g_assert_error (error, G_IO_ERROR, G_IO_ERROR_INVALID_DATA);
+	g_assert_null (silo);
+}
+
+static void
 xb_builder_node_func (void)
 {
 	g_autofree gchar *xml = NULL;
@@ -2641,6 +2659,7 @@ main (int argc, char **argv)
 	g_test_add_func ("/libxmlb/xpath-node", xb_xpath_node_func);
 	g_test_add_func ("/libxmlb/xpath-parent-subnode", xb_xpath_parent_subnode_func);
 	g_test_add_func ("/libxmlb/multiple-roots", xb_builder_multiple_roots_func);
+	g_test_add_func ("/libxmlb/single-root", xb_builder_single_root_func);
 	if (g_test_perf ())
 		g_test_add_func ("/libxmlb/threading", xb_threading_func);
 	if (g_test_perf ())


### PR DESCRIPTION
This is required for programs like fwupd to reject invalid (appended)
metainfo.xml files.