### PR TITLE
Add simple iterator for XbNode attributes

### DIFF
--- a/src/libxmlb.map
+++ b/src/libxmlb.map
@@ -260,3 +260,10 @@ LIBXMLB_0.3.1 {
     xb_builder_node_tokenize_text;
   local: *;
 } LIBXMLB_0.3.0;
+
+LIBXMLB_0.3.4 {
+  global:
+    xb_node_attr_iter_init;
+    xb_node_attr_iter_next;
+  local: *;
+} LIBXMLB_0.3.1;

--- a/src/xb-node.h
+++ b/src/xb-node.h
@@ -49,6 +49,17 @@ typedef enum {
 	XB_NODE_EXPORT_FLAG_LAST
 } XbNodeExportFlags;
 
+typedef struct
+{
+  /*< private >*/
+  gpointer	dummy1;
+  guint8	dummy2;
+  gpointer	dummy3;
+  gpointer	dummy4;
+  gpointer	dummy5;
+  gpointer	dummy6;
+} XbNodeAttrIter;
+
 typedef gboolean (*XbNodeTransmogrifyFunc)	(XbNode		*self,
 						 gpointer	 user_data);
 gboolean	 xb_node_transmogrify		(XbNode		*self,
@@ -80,5 +91,10 @@ guint64		 xb_node_get_attr_as_uint	(XbNode		*self,
 						 const gchar	*name);
 guint		 xb_node_get_depth		(XbNode		*self);
 
+void		 xb_node_attr_iter_init		(XbNodeAttrIter	*iter,
+						 XbNode		*self);
+gboolean	 xb_node_attr_iter_next		(XbNodeAttrIter	*iter,
+						 const gchar	**name,
+						 const gchar	**value);
 
 G_END_DECLS


### PR DESCRIPTION
Hi!
This adds the simplest iterator possible to iterate over all XbNode attributes (can only initialize and go forward). With having something like this, I can convert an XbNode into a libxml2 node using some really simple test code:
```c
static gboolean
as_transmogrify_xbnode_to_xmlnode (XbNode *xbn, xmlNode *lxn)
{
	XbNodeIter attr_iter;
	const gchar *attr_name;
	const gchar *attr_value;
	g_autoptr(GPtrArray) children = NULL;
	g_return_val_if_fail (XB_IS_NODE (xbn), FALSE);

	xmlNodeSetName (lxn,
			(xmlChar*) xb_node_get_element (xbn));
	xmlNodeAddContent (lxn,
			   (xmlChar*) xb_node_get_text (xbn));

	xb_node_attr_iter_init (&attr_iter, xbn);
	while (xb_node_attr_iter_next (&attr_iter, &attr_name, &attr_value))
		xmlNewProp (lxn, (xmlChar*) attr_name, (xmlChar*) attr_value);

	/* all children */
	children = xb_node_get_children (xbn);
	for (guint i = 0; i < children->len; i++) {
		XbNode *c = XB_NODE (g_ptr_array_index (children, i));
		xmlNode *lc = xmlNewChild (lxn, NULL, (xmlChar*) "", NULL);
		if (!as_transmogrify_xbnode_to_xmlnode (c, lc))
			return FALSE;
	}

	return TRUE;
}
```
In AppStream, this reduces the time to show results from my test query by 70-80msec compared to serializing the XbNode to XML and loading it with libxml2 again, which is rather nice!

I intend to maybe extend this and add an iterator for XbNode children as well, reusing the new `XbNodeIter` struct for that as well, to save a GPtrArray allocation and looping through the array twice.

Thanks for considering!