### PR TITLE
Add an iterator for XbNode children

### DIFF
--- a/src/libxmlb.map
+++ b/src/libxmlb.map
@@ -265,5 +265,8 @@ LIBXMLB_0.3.4 {
   global:
     xb_node_attr_iter_init;
     xb_node_attr_iter_next;
+    xb_node_child_iter_init;
+    xb_node_child_iter_loop;
+    xb_node_child_iter_next;
   local: *;
 } LIBXMLB_0.3.1;

--- a/src/xb-node.h
+++ b/src/xb-node.h
@@ -60,6 +60,17 @@ typedef struct
   gpointer	dummy6;
 } XbNodeAttrIter;
 
+typedef struct
+{
+  /*< private >*/
+  gpointer	dummy1;
+  gpointer	dummy2;
+  gboolean	dummy3;
+  gpointer	dummy4;
+  gpointer	dummy5;
+  gpointer	dummy6;
+} XbNodeChildIter;
+
 typedef gboolean (*XbNodeTransmogrifyFunc)	(XbNode		*self,
 						 gpointer	 user_data);
 gboolean	 xb_node_transmogrify		(XbNode		*self,
@@ -96,5 +107,12 @@ void		 xb_node_attr_iter_init		(XbNodeAttrIter	*iter,
 gboolean	 xb_node_attr_iter_next		(XbNodeAttrIter	*iter,
 						 const gchar	**name,
 						 const gchar	**value);
+
+void		 xb_node_child_iter_init	(XbNodeChildIter	*iter,
+						 XbNode			*self);
+gboolean	 xb_node_child_iter_next	(XbNodeChildIter	*iter,
+						 XbNode			**child);
+gboolean	xb_node_child_iter_loop		(XbNodeChildIter	*iter,
+						 XbNode			**child);
 
 G_END_DECLS


### PR DESCRIPTION
Hi!
This is the same style of iterator for XbNode children that ican now also be used for node attributes.
It is more efficient than using the `get_children()` method, and may be more obvious to use than the combination of `get_next()` and `get_child()` (while probably not being faster than those).
