### PR TITLE
build: Require Python explicitly

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -151,7 +151,7 @@ configure_file(
 )
 
 python = import('python')
-python3 = python.find_installation()
+python3 = python.find_installation('python3')
 
 subdir('data')
 subdir('src')


### PR DESCRIPTION
When the first argument to python.find_installation is omitted, Meson will return the Python instance used to run it. But that can be a completely different installation than the one on PATH.

This change was initially introduced in https://github.com/hughsie/libxmlb/commit/ca94c2ebfed0c9c370279fdba5ad4d03456be5b6 but reverted in https://github.com/hughsie/libxmlb/commit/9d520fff9aae1028ada992a3252de52c79d940b2 due to concern about FreeBSD 12.2. But FreeBSD 12.2 installs python3 on PATH nowadays and even if it did not, the inability to find Python is a [bug to fix in Meson](https://github.com/mesonbuild/meson/issues/4608).

cc @Asiderr (https://github.com/hughsie/libxmlb/pull/92)