### PR TITLE
meson: use the correct lookup method for the python3 script interpreter

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,3 +4,6 @@ root = true
 [*]
 indent_style = tab
 indent_size = 8
+
+[*.py]
+indent_style = space

--- a/meson.build
+++ b/meson.build
@@ -150,8 +150,7 @@ configure_file(
   configuration : conf
 )
 
-python = import('python')
-python3 = python.find_installation()
+python3 = find_program('python3')
 
 subdir('data')
 subdir('src')

--- a/src/generate-version-script.py
+++ b/src/generate-version-script.py
@@ -9,11 +9,12 @@ import sys
 import argparse
 import xml.etree.ElementTree as ET
 
-from pkg_resources import parse_version
-
 XMLNS = "{http://www.gtk.org/introspection/core/1.0}"
 XMLNS_C = "{http://www.gtk.org/introspection/c/1.0}"
 
+
+def parse_version(ver):
+    return tuple(map(int, ver.split('.')))
 
 def usage(return_code):
     """print usage and exit with the supplied return code"""


### PR DESCRIPTION
The python module's find_installation method is incorrect -- it does a variety of things geared towards building and installing python modules into site-packages. This is slow and inefficient and completely pointless -- all that is needed here is to run scripts.

find_program() is guaranteed to find the python3 interpreter too, and is the correct way to find *any* other program, so use it for python as well.