### PR TITLE
Ignore all hidden files when using _WATCH_DIRECTORY

### DIFF
--- a/src/xb-silo.c
+++ b/src/xb-silo.c
@@ -876,7 +876,7 @@ xb_silo_watch_file_cb(GFileMonitor *monitor,
 	XbSilo *silo = XB_SILO(user_data);
 	g_autofree gchar *fn = g_file_get_path(file);
 	g_autofree gchar *basename = g_file_get_basename(file);
-	if (g_str_has_prefix(basename, ".goutputstream"))
+	if (g_str_has_prefix(basename, "."))
 		return;
 	g_debug("%s changed, invalidating", fn);
 	xb_silo_invalidate(silo);


### PR DESCRIPTION
We already ignore the GFile-default file prefix, but it's much clearer
to just ignore all hidden files.

Fixes https://github.com/hughsie/libxmlb/issues/117