### PR TITLE
build: fix building on macOS

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -69,7 +69,7 @@ libxmlb = library(
     configinc,
   ],
   dependencies : libxmlb_deps,
-  link_args : vflag,
+  link_args : cc.get_supported_link_arguments([vflag]),
   link_depends : mapfile,
   install : true
 )


### PR DESCRIPTION
`--version-script` isn't supported by the macOS linker and build fails with:

```
ld: unknown option: --version-script
```

Many thanks to @jtojnar for helping with this, with this fix libxmlb builds on x86_64-darwin now (I added you as a co-author hope you don't mind).

See also: https://github.com/GNOME/gcab/commit/14fe32b0759bf907303c9646e272c796d0bf7d37