### PR TITLE
Fix a crash for when the root tree has no children

### DIFF
--- a/src/xb-builder.c
+++ b/src/xb-builder.c
@@ -254,6 +254,15 @@ xb_builder_compile_source(XbBuilderCompileHelper *helper,
 	if (!xb_builder_source_fixup(source, root_tmp, error))
 		return FALSE;
 
+	/* check to see if the root was ignored */
+	if (xb_builder_node_has_flag(root_tmp, XB_BUILDER_NODE_FLAG_IGNORE)) {
+		g_set_error_literal(error,
+				    G_IO_ERROR,
+				    G_IO_ERROR_INVALID_DATA,
+				    "root node cannot be ignored");
+		return FALSE;
+	}
+
 	/* a single root with no siblings was required */
 	if (helper->compile_flags & XB_BUILDER_COMPILE_FLAG_SINGLE_ROOT) {
 		if (xb_builder_node_get_children(root_tmp)->len > 1) {

--- a/src/xb-builder.c
+++ b/src/xb-builder.c
@@ -280,7 +280,8 @@ xb_builder_compile_source(XbBuilderCompileHelper *helper,
 		children = xb_builder_node_get_children(helper->current);
 		for (guint i = 0; i < children->len; i++) {
 			XbBuilderNode *bn = g_ptr_array_index(children, i);
-			xb_builder_node_add_child(bn, info);
+			if (!xb_builder_node_has_flag(bn, XB_BUILDER_NODE_FLAG_IGNORE))
+				xb_builder_node_add_child(bn, info);
 		}
 	}
 

--- a/src/xb-node.c
+++ b/src/xb-node.c
@@ -478,7 +478,7 @@ xb_node_get_tail(XbNode *self)
  *
  * Gets the element name for a specific node.
  *
- * Returns: a string, or %NULL for unset
+ * Returns: a string, or %NULL for the root node
  *
  * Since: 0.1.0
  **/
@@ -487,6 +487,8 @@ xb_node_get_element(XbNode *self)
 {
 	XbNodePrivate *priv = GET_PRIVATE(self);
 	g_return_val_if_fail(XB_IS_NODE(self), NULL);
+	if (priv->sn == NULL)
+		return NULL;
 	return xb_silo_get_node_element(priv->silo, priv->sn);
 }
 
@@ -634,6 +636,8 @@ xb_node_get_depth(XbNode *self)
 {
 	XbNodePrivate *priv = GET_PRIVATE(self);
 	g_return_val_if_fail(XB_IS_NODE(self), 0);
+	if (priv->sn == NULL)
+		return 0;
 	return xb_silo_get_node_depth(priv->silo, priv->sn);
 }
 

--- a/src/xb-node.c
+++ b/src/xb-node.c
@@ -248,6 +248,8 @@ xb_node_get_child(XbNode *self)
 
 	g_return_val_if_fail(XB_IS_NODE(self), NULL);
 
+	if (priv->sn == NULL)
+		return NULL;
 	sn = xb_silo_get_child_node(priv->silo, priv->sn);
 	if (sn == NULL)
 		return NULL;

--- a/src/xb-node.c
+++ b/src/xb-node.c
@@ -200,6 +200,8 @@ xb_node_get_parent(XbNode *self)
 
 	g_return_val_if_fail(XB_IS_NODE(self), NULL);
 
+	if (priv->sn == NULL)
+		return NULL;
 	sn = xb_silo_get_parent_node(priv->silo, priv->sn);
 	if (sn == NULL)
 		return NULL;
@@ -224,6 +226,8 @@ xb_node_get_next(XbNode *self)
 
 	g_return_val_if_fail(XB_IS_NODE(self), NULL);
 
+	if (priv->sn == NULL)
+		return NULL;
 	sn = xb_silo_get_next_node(priv->silo, priv->sn);
 	if (sn == NULL)
 		return NULL;
@@ -303,7 +307,7 @@ xb_node_child_iter_init(XbNodeChildIter *iter, XbNode *self)
 	g_return_if_fail(XB_IS_NODE(self));
 
 	ri->node = self;
-	ri->position = xb_silo_get_child_node(priv->silo, priv->sn);
+	ri->position = priv->sn != NULL ? xb_silo_get_child_node(priv->silo, priv->sn) : NULL;
 	ri->first_iter = TRUE;
 }
 
@@ -424,6 +428,8 @@ xb_node_get_text(XbNode *self)
 {
 	XbNodePrivate *priv = GET_PRIVATE(self);
 	g_return_val_if_fail(XB_IS_NODE(self), NULL);
+	if (priv->sn == NULL)
+		return NULL;
 	return xb_silo_get_node_text(priv->silo, priv->sn);
 }
 
@@ -445,8 +451,9 @@ xb_node_get_text_as_uint(XbNode *self)
 
 	g_return_val_if_fail(XB_IS_NODE(self), G_MAXUINT64);
 
+	if (priv->sn == NULL)
+		return G_MAXUINT64;
 	tmp = xb_silo_get_node_text(priv->silo, priv->sn);
-	;
 	if (tmp == NULL)
 		return G_MAXUINT64;
 	if (g_str_has_prefix(tmp, "0x"))
@@ -469,6 +476,8 @@ xb_node_get_tail(XbNode *self)
 {
 	XbNodePrivate *priv = GET_PRIVATE(self);
 	g_return_val_if_fail(XB_IS_NODE(self), NULL);
+	if (priv->sn == NULL)
+		return NULL;
 	return xb_silo_get_node_tail(priv->silo, priv->sn);
 }
 
@@ -512,6 +521,8 @@ xb_node_get_attr(XbNode *self, const gchar *name)
 	g_return_val_if_fail(XB_IS_NODE(self), NULL);
 	g_return_val_if_fail(name != NULL, NULL);
 
+	if (priv->sn == NULL)
+		return NULL;
 	a = xb_silo_get_node_attr_by_str(priv->silo, priv->sn, name);
 	if (a == NULL)
 		return NULL;
@@ -567,7 +578,7 @@ xb_node_attr_iter_init(XbNodeAttrIter *iter, XbNode *self)
 	g_return_if_fail(XB_IS_NODE(self));
 
 	ri->node = self;
-	ri->position = xb_silo_node_get_attr_count(priv->sn);
+	ri->position = priv->sn != NULL ? xb_silo_node_get_attr_count(priv->sn) : 0;
 }
 
 /**

--- a/src/xb-self-test.c
+++ b/src/xb-self-test.c
@@ -739,6 +739,7 @@ static void
 xb_builder_node_vfunc_ignore_func(void)
 {
 	gboolean ret;
+	const gchar *element;
 	g_autoptr(GError) error = NULL;
 	g_autoptr(XbBuilder) builder = xb_builder_new();
 	g_autoptr(XbBuilderFixup) fixup = NULL;
@@ -764,6 +765,8 @@ xb_builder_node_vfunc_ignore_func(void)
 	g_assert_nonnull(silo);
 	n = xb_silo_get_root(silo);
 	g_assert_nonnull(n);
+	element = xb_node_get_element(n);
+	g_assert_null(element);
 	c = xb_node_get_child(n);
 	g_assert_null(c);
 }

--- a/src/xb-self-test.c
+++ b/src/xb-self-test.c
@@ -731,7 +731,8 @@ xb_builder_node_vfunc_error_func(void)
 static gboolean
 xb_builder_ignore_cb(XbBuilderFixup *self, XbBuilderNode *bn, gpointer user_data, GError **error)
 {
-	xb_builder_node_add_flag(bn, XB_BUILDER_NODE_FLAG_IGNORE);
+	if (xb_builder_node_get_element(bn) != NULL)
+		xb_builder_node_add_flag(bn, XB_BUILDER_NODE_FLAG_IGNORE);
 	return TRUE;
 }
 

--- a/src/xb-self-test.c
+++ b/src/xb-self-test.c
@@ -729,6 +729,46 @@ xb_builder_node_vfunc_error_func(void)
 }
 
 static gboolean
+xb_builder_ignore_cb(XbBuilderFixup *self, XbBuilderNode *bn, gpointer user_data, GError **error)
+{
+	xb_builder_node_add_flag(bn, XB_BUILDER_NODE_FLAG_IGNORE);
+	return TRUE;
+}
+
+static void
+xb_builder_node_vfunc_ignore_func(void)
+{
+	gboolean ret;
+	g_autoptr(GError) error = NULL;
+	g_autoptr(XbBuilder) builder = xb_builder_new();
+	g_autoptr(XbBuilderFixup) fixup = NULL;
+	g_autoptr(XbBuilderSource) source = xb_builder_source_new();
+	g_autoptr(XbSilo) silo = NULL;
+	g_autoptr(XbNode) n = NULL;
+	g_autoptr(XbNode) c = NULL;
+
+	/* add fixup */
+	fixup = xb_builder_fixup_new("AlwaysIgnore", xb_builder_ignore_cb, NULL, NULL);
+	xb_builder_source_add_fixup(source, fixup);
+
+	/* import some XML */
+	ret = xb_builder_source_load_xml(source,
+					 "<component><id>gimp.desktop</id></component>",
+					 XB_BUILDER_SOURCE_FLAG_NONE,
+					 &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+	xb_builder_import_source(builder, source);
+	silo = xb_builder_compile(builder, XB_BUILDER_COMPILE_FLAG_NONE, NULL, &error);
+	g_assert_no_error(error);
+	g_assert_nonnull(silo);
+	n = xb_silo_get_root(silo);
+	g_assert_nonnull(n);
+	c = xb_node_get_child(n);
+	g_assert_null(c);
+}
+
+static gboolean
 xb_builder_upgrade_appstream_cb(XbBuilderFixup *self,
 				XbBuilderNode *bn,
 				gpointer user_data,
@@ -2681,6 +2721,7 @@ main(int argc, char **argv)
 	g_test_add_func("/libxmlb/builder{node-vfunc-remove}", xb_builder_node_vfunc_remove_func);
 	g_test_add_func("/libxmlb/builder{node-vfunc-depth}", xb_builder_node_vfunc_depth_func);
 	g_test_add_func("/libxmlb/builder{node-vfunc-error}", xb_builder_node_vfunc_error_func);
+	g_test_add_func("/libxmlb/builder{node-vfunc-ignore}", xb_builder_node_vfunc_ignore_func);
 	g_test_add_func("/libxmlb/builder{ignore-invalid}", xb_builder_ignore_invalid_func);
 	g_test_add_func("/libxmlb/builder{custom-mime}", xb_builder_custom_mime_func);
 	g_test_add_func("/libxmlb/builder{chained-adapters}", xb_builder_chained_adapters_func);

--- a/src/xb-self-test.c
+++ b/src/xb-self-test.c
@@ -739,6 +739,7 @@ xb_builder_ignore_cb(XbBuilderFixup *self, XbBuilderNode *bn, gpointer user_data
 static void
 xb_builder_node_vfunc_ignore_func(void)
 {
+	XbNodeChildIter iter;
 	gboolean ret;
 	const gchar *element;
 	g_autoptr(GError) error = NULL;
@@ -749,6 +750,7 @@ xb_builder_node_vfunc_ignore_func(void)
 	g_autoptr(XbSilo) silo = NULL;
 	g_autoptr(XbNode) n = NULL;
 	g_autoptr(XbNode) c = NULL;
+	g_autoptr(XbNode) c2 = NULL;
 
 	/* add fixup */
 	fixup = xb_builder_fixup_new("AlwaysIgnore", xb_builder_ignore_cb, NULL, NULL);
@@ -776,6 +778,12 @@ xb_builder_node_vfunc_ignore_func(void)
 	g_assert_null(element);
 	c = xb_node_get_child(n);
 	g_assert_null(c);
+	c = xb_node_get_next(n);
+	g_assert_null(c);
+	xb_node_child_iter_init(&iter, n);
+	ret = xb_node_child_iter_next(&iter, &c2);
+	g_assert_false(ret);
+	g_assert_null(c2);
 }
 
 static gboolean

--- a/src/xb-self-test.c
+++ b/src/xb-self-test.c
@@ -745,6 +745,7 @@ xb_builder_node_vfunc_ignore_func(void)
 	g_autoptr(XbBuilder) builder = xb_builder_new();
 	g_autoptr(XbBuilderFixup) fixup = NULL;
 	g_autoptr(XbBuilderSource) source = xb_builder_source_new();
+	g_autoptr(XbBuilderNode) info = NULL;
 	g_autoptr(XbSilo) silo = NULL;
 	g_autoptr(XbNode) n = NULL;
 	g_autoptr(XbNode) c = NULL;
@@ -753,14 +754,19 @@ xb_builder_node_vfunc_ignore_func(void)
 	fixup = xb_builder_fixup_new("AlwaysIgnore", xb_builder_ignore_cb, NULL, NULL);
 	xb_builder_source_add_fixup(source, fixup);
 
-	/* import some XML */
+	/* import some XML with metadata */
 	ret = xb_builder_source_load_xml(source,
 					 "<component><id>gimp.desktop</id></component>",
 					 XB_BUILDER_SOURCE_FLAG_NONE,
 					 &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
+	info = xb_builder_node_insert(NULL, "info", NULL);
+	xb_builder_node_insert_text(info, "foo", "bar", NULL);
+	xb_builder_source_set_info(source, info);
 	xb_builder_import_source(builder, source);
+
+	/* compile */
 	silo = xb_builder_compile(builder, XB_BUILDER_COMPILE_FLAG_NONE, NULL, &error);
 	g_assert_no_error(error);
 	g_assert_nonnull(silo);


### PR DESCRIPTION
This will only happen when using xb_node_get_child(xb_silo_get_root()).

Fixes https://github.com/hughsie/libxmlb/issues/120