### PR TITLE
Fix dumping and exporting multiple files from the CLI

### DIFF
--- a/src/xb-machine.c
+++ b/src/xb-machine.c
@@ -1061,8 +1061,7 @@ xb_machine_run_with_bindings(XbMachine *self,
 			    tmp);
 		return FALSE;
 	}
-	if (result != NULL)
-		*result = xb_opcode_get_val(&opcode_success);
+	*result = xb_opcode_get_val(&opcode_success);
 
 	/* success */
 	return TRUE;

--- a/src/xb-self-test.c
+++ b/src/xb-self-test.c
@@ -2764,9 +2764,9 @@ main(int argc, char **argv)
 	g_test_add_func("/libxmlb/xpath-parent-subnode", xb_xpath_parent_subnode_func);
 	g_test_add_func("/libxmlb/multiple-roots", xb_builder_multiple_roots_func);
 	g_test_add_func("/libxmlb/single-root", xb_builder_single_root_func);
-	if (g_test_perf())
+	if (g_test_perf()) {
 		g_test_add_func("/libxmlb/threading", xb_threading_func);
-	if (g_test_perf())
 		g_test_add_func("/libxmlb/speed", xb_speed_func);
+	}
 	return g_test_run();
 }

--- a/src/xb-tool.c
+++ b/src/xb-tool.c
@@ -188,7 +188,7 @@ xb_tool_dump(XbToolPrivate *priv, gchar **values, GError **error)
 	/* load blobs */
 	for (guint i = 0; values[i] != NULL; i++) {
 		g_autofree gchar *str = NULL;
-		g_autoptr(GFile) file = g_file_new_for_path(values[0]);
+		g_autoptr(GFile) file = g_file_new_for_path(values[i]);
 		g_autoptr(XbSilo) silo = xb_silo_new();
 		if (!xb_silo_load_from_file(silo, file, flags, NULL, error))
 			return FALSE;
@@ -223,7 +223,7 @@ xb_tool_export(XbToolPrivate *priv, gchar **values, GError **error)
 	/* load blobs */
 	for (guint i = 0; values[i] != NULL; i++) {
 		g_autofree gchar *str = NULL;
-		g_autoptr(GFile) file = g_file_new_for_path(values[0]);
+		g_autoptr(GFile) file = g_file_new_for_path(values[i]);
 		g_autoptr(XbSilo) silo = xb_silo_new();
 		if (!xb_silo_load_from_file(silo, file, flags, NULL, error))
 			return FALSE;


### PR DESCRIPTION
PVS: Suspicious access to element of 'values' array by a constant index inside a loop.