### PR TITLE
Add limited support for XPath 1.0 'in'

### DIFF
--- a/src/xb-machine.h
+++ b/src/xb-machine.h
@@ -65,12 +65,14 @@ typedef gboolean (*XbMachineOpcodeFixupFunc)(XbMachine *self,
 					     XbStack *opcodes,
 					     gpointer user_data,
 					     GError **error);
+/* when next breaking API add @level here */
 typedef gboolean (*XbMachineTextHandlerFunc)(XbMachine *self,
 					     XbStack *opcodes,
 					     const gchar *text,
 					     gboolean *handled,
 					     gpointer user_data,
 					     GError **error);
+/* when next breaking API add @level here */
 typedef gboolean (*XbMachineMethodFunc)(XbMachine *self,
 					XbStack *stack,
 					gboolean *result_unused,

--- a/src/xb-opcode-private.h
+++ b/src/xb-opcode-private.h
@@ -23,11 +23,12 @@ struct _XbOpcode {
 	guint8 tokens_len;
 	const gchar *tokens[XB_OPCODE_TOKEN_MAX + 1];
 	GDestroyNotify destroy_func;
+	guint8 level;
 };
 
 #define XB_OPCODE_INIT()                                                                           \
 	{                                                                                          \
-		0, 0, NULL, 0, {NULL}, NULL                                                        \
+		0, 0, NULL, 0, {NULL}, NULL, 0                                                     \
 	}
 
 /**
@@ -82,6 +83,11 @@ gboolean
 xb_opcode_has_flag(XbOpcode *self, XbOpcodeFlags flag);
 void
 xb_opcode_add_flag(XbOpcode *self, XbOpcodeFlags flag);
+
+void
+xb_opcode_set_level(XbOpcode *self, guint8 level);
+guint8
+xb_opcode_get_level(XbOpcode *self);
 
 G_DEFINE_AUTO_CLEANUP_CLEAR_FUNC(XbOpcode, xb_opcode_clear)
 

--- a/src/xb-silo.c
+++ b/src/xb-silo.c
@@ -1177,12 +1177,19 @@ xb_silo_machine_fixup_position_cb(XbMachine *self,
 {
 	XbOpcode *op1;
 	XbOpcode *op2;
+	XbOpcode *tail = xb_stack_peek_tail(opcodes);
 
 	if (!_xb_stack_push_two(opcodes, &op1, &op2, error))
 		return FALSE;
 
 	xb_machine_opcode_func_init(self, op1, "position");
 	xb_machine_opcode_func_init(self, op2, "eq");
+
+	/* always exists, but maybe a @level would be cleaner */
+	if (tail != NULL) {
+		xb_opcode_set_level(op1, xb_opcode_get_level(tail));
+		xb_opcode_set_level(op2, xb_opcode_get_level(tail));
+	}
 
 	return TRUE;
 }
@@ -1196,12 +1203,19 @@ xb_silo_machine_fixup_attr_exists_cb(XbMachine *self,
 {
 	XbOpcode *op1;
 	XbOpcode *op2;
+	XbOpcode *tail = xb_stack_peek_tail(opcodes);
 
 	if (!_xb_stack_push_two(opcodes, &op1, &op2, error))
 		return FALSE;
 
 	xb_opcode_text_init_static(op1, NULL);
 	xb_machine_opcode_func_init(self, op2, "ne");
+
+	/* always exists, but maybe a @level would be cleaner */
+	if (tail != NULL) {
+		xb_opcode_set_level(op1, xb_opcode_get_level(tail));
+		xb_opcode_set_level(op2, xb_opcode_get_level(tail));
+	}
 
 	return TRUE;
 }


### PR DESCRIPTION
For example, `text()=('a','b','c')`.