### PR TITLE
xb-silo: skip xb_query_to_string() unless error is set

### DIFF
--- a/src/xb-silo-query.c
+++ b/src/xb-silo-query.c
@@ -543,12 +543,14 @@ xb_silo_query_with_root_full(XbSilo *self,
 
 	/* nothing found */
 	if (results->len == 0) {
-		g_autofree gchar *tmp = xb_query_to_string(query);
-		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_FOUND,
-			    "no results for XPath query '%s'",
-			    tmp);
+		if (error != NULL) {
+			g_autofree gchar *tmp = xb_query_to_string(query);
+			g_set_error(error,
+				    G_IO_ERROR,
+				    G_IO_ERROR_NOT_FOUND,
+				    "no results for XPath query '%s'",
+				    tmp);
+		}
 		return NULL;
 	}
 


### PR DESCRIPTION
If xb_silo_query_with_root_full() is called without a GError, then there is no need to format the query for a GError that will be discarded.

In GNOME Software, for example, this could be called 70,000 times for a trivial query via GNOME Shell. Avoiding this saves about 4% of CPU on an idle system transitioning to Shell search.