### PR TITLE
trivial: Only tokenize when using ~= for the first time

### DIFF
--- a/src/xb-machine.c
+++ b/src/xb-machine.c
@@ -1078,10 +1078,6 @@ xb_machine_run_with_bindings(XbMachine *self,
 				}
 				return FALSE;
 			}
-
-			/* this cannot be optimized away when constructing the query */
-			if (_xb_opcode_get_kind(machine_opcode) == XB_OPCODE_KIND_BOUND_TEXT)
-				xb_machine_opcode_tokenize(self, machine_opcode);
 			continue;
 		}
 		if (kind == XB_OPCODE_KIND_BOUND_UNSET) {

--- a/src/xb-silo.c
+++ b/src/xb-silo.c
@@ -1517,6 +1517,16 @@ xb_silo_machine_func_search_cb(XbMachine *self,
 	if (!xb_machine_stack_pop_two(self, stack, &op1, &op2, error))
 		return FALSE;
 
+	/* this cannot be optimized away when constructing the query */
+	if (!_xb_opcode_has_flag(&op1, XB_OPCODE_FLAG_TOKENIZED) &&
+	    _xb_opcode_get_kind(&op1) == XB_OPCODE_KIND_BOUND_TEXT) {
+		xb_machine_opcode_tokenize(self, &op1);
+	}
+	if (!_xb_opcode_has_flag(&op2, XB_OPCODE_FLAG_TOKENIZED) &&
+	    _xb_opcode_get_kind(&op2) == XB_OPCODE_KIND_BOUND_TEXT) {
+		xb_machine_opcode_tokenize(self, &op2);
+	}
+
 	/* TOKN:TOKN */
 	if (xb_opcode_has_flag(&op1, XB_OPCODE_FLAG_TOKENIZED) &&
 	    xb_opcode_has_flag(&op2, XB_OPCODE_FLAG_TOKENIZED)) {


### PR DESCRIPTION
We don't want the penalty of tokenizing for the most common == operator.