### PR TITLE
Windows: Support building with clang-cl

### DIFF
--- a/src/gen-def-from-map.py
+++ b/src/gen-def-from-map.py
@@ -1,0 +1,100 @@
+#!/usr/bin/python3
+# pylint: disable=invalid-name,missing-docstring
+#
+# Copyright (C) 2023 Chun-wei Fan <fanc999@yahoo.com.tw>
+#
+# SPDX-License-Identifier: LGPL-2.1+
+
+# Script to generate .def file from .map files
+
+import os
+import re
+import sys
+
+def get_sym_groups(lines, namespace):
+    sym_groups = []
+    search_header = True
+    collect_symbols = False
+    search_tail = False
+
+    # namespace + version of library
+    namespace_with_ver_regex = re.escape(namespace) + \
+                           r"_[0-9]+\.[0-9]+\.[0-9]+"
+    # Look for symbols added in version in library from map file,
+    # which defines a group of symbols
+    header_regex = re.compile(r"^" + namespace_with_ver_regex)
+    # Look for where to start collecting symbols for the group
+    global_regex = re.compile(r"^\s+global:\s+$")
+    # Look for where to end collecting symbols for the group
+    local_regex = re.compile(r"^\s+local:\s+\*+;\s+$")
+    # Look, if any, since which version were the symbols
+    # group added
+    ending_notail_regex = re.compile(r"^};\s+$")
+    ending_tail_regex = \
+      re.compile(r"^}\s+" + namespace_with_ver_regex + ";\s+$")
+
+    for l in lines:
+        # New symbols group found in map file
+        if search_header and header_regex.match(l):
+            symbols = []
+            header = l.split()[0]
+            search_header = False
+
+        # Go through map file to gather up info for this symbols group
+        elif not search_header:
+            if not collect_symbols and global_regex.match(l):
+                collect_symbols = True
+            elif collect_symbols:
+                tail = None
+
+                # Stop gathering for group if `local: *;` is found
+                if local_regex.match(l):
+                    search_tail = True
+                elif search_tail:
+                    # Populate symbols group info and append
+                    # to the groups we gathered previously
+                    if ending_notail_regex.match(l) or \
+                       ending_tail_regex.match(l):
+                        if ending_tail_regex.match(l):
+                            tail_ = l.split()[1]
+                            tail = tail_[:tail_.index(';')]
+                        sym_group = {
+                          "header": header,
+                          "symbols": symbols,
+                          "tail": tail,
+                        }
+                        sym_groups.append(sym_group)
+                        search_tail = False
+                        collect_symbols = False
+                        search_header = True
+
+                # Gather up symbols for this group
+                else:
+                    symbol = l[:l.index(';')].strip()
+                    symbols.append(symbol)
+
+    return sym_groups
+
+def output_def_file(def_file, sym_groups):
+    with open(def_file, 'w') as out:
+        out.write('EXPORTS\n')
+        for group in sym_groups:
+            out.write('\n')
+            if group['tail'] is not None:
+                out.write('; APIs added in %s since %s\n' % 
+                          (group['header'], group['tail']))
+            else:
+                out.write('; APIs added in %s\n' % group['header'])
+            for symbol in group['symbols']:
+                out.write('%s\n' % symbol)
+
+if __name__ == "__main__":
+    if len(sys.argv) != 4:
+        raise SystemExit('%s <mapfile> <namespace> <deffile>' % sys.argv[0])
+    mapfile = sys.argv[1]
+    namespace = sys.argv[2]
+    def_file =  sys.argv[3]
+    with open(mapfile, 'r') as m:
+        lines = m.readlines()
+        groups = get_sym_groups(lines, namespace)
+        output_def_file(def_file, groups)

--- a/src/generate-version-script.py
+++ b/src/generate-version-script.py
@@ -139,4 +139,4 @@ if __name__ == "__main__":
         for override_symbol, override_version in args.override:
             ld.overrides[override_symbol] = override_version
     ld.import_gir(argv[1])
-    open(argv[2], "w").write(ld.render())
+    open(argv[2], "w", newline="\n").write(ld.render())

--- a/src/meson.build
+++ b/src/meson.build
@@ -43,6 +43,20 @@ extra_sources = []
 if get_option('zstd')
     extra_sources += ['xb-zstd-decompressor.c']
 endif
+
+def_file_target = custom_target(
+  'libxmlb-defile',
+  input: mapfile,
+  output: 'libxmlb.def',
+  command: [
+    python3,
+    join_paths(meson.current_source_dir(), 'gen-def-from-map.py'),
+    '@INPUT@',
+    'LIBXMLB',
+    '@OUTPUT@',
+  ],
+)
+
 libxmlb = library(
   'xmlb',
   sources : [
@@ -74,6 +88,7 @@ libxmlb = library(
   dependencies : libxmlb_deps,
   c_args : release_args,
   link_args : cc.get_supported_link_arguments([vflag]),
+  vs_module_defs: def_file_target,
   link_depends : mapfile,
   install : true
 )

--- a/src/xb-machine.h
+++ b/src/xb-machine.h
@@ -86,9 +86,8 @@ XbMachine *
 xb_machine_new(void);
 void
 xb_machine_set_debug_flags(XbMachine *self, XbMachineDebugFlags flags);
-XbStack *
-xb_machine_parse(XbMachine *self, const gchar *text, gssize text_len, GError **error)
-    G_DEPRECATED_FOR(xb_machine_parse_full);
+G_DEPRECATED_FOR(xb_machine_parse_full) XbStack *
+xb_machine_parse(XbMachine *self, const gchar *text, gssize text_len, GError **error);
 XbStack *
 xb_machine_parse_full(XbMachine *self,
 		      const gchar *text,

--- a/src/xb-opcode.c
+++ b/src/xb-opcode.c
@@ -220,7 +220,7 @@ xb_opcode_add_flag(XbOpcode *self, XbOpcodeFlags flag)
  *
  * Since: 0.1.1
  **/
-inline gboolean
+gboolean
 xb_opcode_cmp_val(XbOpcode *self)
 {
 	return _xb_opcode_cmp_int(self) || _xb_opcode_cmp_itx(self);
@@ -236,7 +236,7 @@ xb_opcode_cmp_val(XbOpcode *self)
  *
  * Since: 0.1.1
  **/
-inline gboolean
+gboolean
 xb_opcode_cmp_str(XbOpcode *self)
 {
 	return xb_opcode_has_flag(self, XB_OPCODE_FLAG_TEXT);

--- a/src/xb-silo.c
+++ b/src/xb-silo.c
@@ -215,7 +215,7 @@ xb_silo_strtab_index_lookup(XbSilo *self, const gchar *str)
 }
 
 /* private */
-inline XbSiloNode *
+XbSiloNode *
 xb_silo_get_node(XbSilo *self, guint32 off)
 {
 	XbSiloPrivate *priv = GET_PRIVATE(self);


### PR DESCRIPTION
Hi,

This attempts to support building libxmlb for Windows using clang-cl, so that Visual Studio 2015 (or so, or later) is able to utilize libxmlb as a dependency, where the following is addressed:

*  Fix linking the libxmlb DLL, as shared code cannot be `inline`ed and be used across different compilation units in at least the clang-cl builds (let me know if having the `inline`ed implementation in the headers themselves is preferred).
*  Use `__declspec(dllexport)` to export symbols from the libxmlb DLL (static builds using clang-cl is not yet supported before or after this PR)-this is required for clang-cl to export the libxmlb symbols, sadly, and requires decorating public symbols as needed.
* Make `generate-version-script.py` output `libxmlb.map` with LR line endings, so that the `libxmlb-exported-api` test won't fail due to differing line endings (clang-cl builds using the Visual Studio command prompt, meaning Python will output in CR/LF line endings by default).

With blessings, thank you!