### PR TITLE
Fixing the Assertion of MIME Types Used by Parser

### DIFF
--- a/src/xb-builder-source.c
+++ b/src/xb-builder-source.c
@@ -467,6 +467,8 @@ xb_builder_source_get_istream(XbBuilderSource *self, GCancellable *cancellable, 
 			return NULL;
 		if (g_strcmp0(content_type, "application/xml") == 0)
 			break;
+		/* Also accept the text/xml alias, just in case the user’s content-type database is slightly broken
+		 * (application/xml should normally be what’s used): */
 		if (g_strcmp0(content_type, "text/xml") == 0)
 			break;
 

--- a/src/xb-builder-source.c
+++ b/src/xb-builder-source.c
@@ -465,9 +465,11 @@ xb_builder_source_get_istream(XbBuilderSource *self, GCancellable *cancellable, 
 		content_type = xb_builder_source_ctx_get_content_type(ctx, cancellable, error);
 		if (content_type == NULL)
 			return NULL;
-		if (g_strcmp0(content_type, "application/xml") == 0)
-			break;
 
+		if ((g_strcmp0(content_type, "text/xml") == 0) &&
+		    	(g_strcmp0(content_type, "application/xml" == 0)))
+			break;
+		
 		/* convert the stream */
 		item = xb_builder_source_get_adapter_by_mime(self, content_type);
 		if (item == NULL || item->func_adapter == NULL) {

--- a/src/xb-builder-source.c
+++ b/src/xb-builder-source.c
@@ -467,6 +467,8 @@ xb_builder_source_get_istream(XbBuilderSource *self, GCancellable *cancellable, 
 			return NULL;
 		if (g_strcmp0(content_type, "application/xml") == 0)
 			break;
+		if (g_strcmp0(content_type, "text/xml") == 0)
+			break;
 
 		/* convert the stream */
 		item = xb_builder_source_get_adapter_by_mime(self, content_type);

--- a/src/xb-builder-source.c
+++ b/src/xb-builder-source.c
@@ -465,11 +465,9 @@ xb_builder_source_get_istream(XbBuilderSource *self, GCancellable *cancellable, 
 		content_type = xb_builder_source_ctx_get_content_type(ctx, cancellable, error);
 		if (content_type == NULL)
 			return NULL;
-
-		if ((g_strcmp0(content_type, "text/xml") == 0) &&
-		    	(g_strcmp0(content_type, "application/xml" == 0)))
+		if (g_strcmp0(content_type, "application/xml") == 0)
 			break;
-		
+
 		/* convert the stream */
 		item = xb_builder_source_get_adapter_by_mime(self, content_type);
 		if (item == NULL || item->func_adapter == NULL) {


### PR DESCRIPTION
Some system reports text/xml instead of application/xml as result of g_content_type_guess, in src/xb_common.c, line 73.
```
gchar *
xb_content_type_guess(const gchar *filename, const guchar *buf, gsize bufsz)
{
	g_autofree gchar *content_type = NULL;

	/* check for bad results, e.g. from Chrome OS */
	content_type = g_content_type_guess(filename, buf, bufsz, NULL);    //Here
	if (g_strstr_len(content_type, -1, "/") == NULL ||
	    g_strcmp0(content_type, "application/octet-stream") == 0 ||
	    g_strcmp0(content_type, "text/plain") == 0) {
		/* magic */
		if (bufsz > 0) {
			if (xb_content_type_match(buf, bufsz, 0x0, "\x1f\x8b", 2))
				return g_strdup("application/gzip");
			if (xb_content_type_match(buf, bufsz, 0x0, "\xfd\x37\x7a\x58\x5a\x00", 6))
				return g_strdup("application/x-xz");
			if (xb_content_type_match(buf, bufsz, 0x0, "\x28\xb5\x2f\xfd", 4))
				return g_strdup("application/zstd");
			if (xb_content_type_match(buf, bufsz, 0x0, "<?xml", 5))
				return g_strdup("application/xml");
			if (xb_content_type_match(buf, bufsz, 0x0, "[Desktop Entry]", 15))
				return g_strdup("application/x-desktop");
		}
``` 
So as a result we shouldn't just accept application/xml, which may cause serious bugs. In fact, I found this bug when tracing my malfunctioned gnome software center.