### PR TITLE
Fix decompressing large zstd files, harder

### DIFF
--- a/src/xb-zstd-decompressor.c
+++ b/src/xb-zstd-decompressor.c
@@ -101,14 +101,8 @@ xb_zstd_decompressor_convert(GConverter *converter,
 	*bytes_read = input.pos;
 	*bytes_written = output.pos;
 
-	/* decoder has more to convert */
-	if (input.pos < input.size)
-		return G_CONVERTER_CONVERTED;
-	if (output.pos >= output.size)
-		return G_CONVERTER_CONVERTED;
-
 	/* success */
-	return G_CONVERTER_FINISHED;
+	return res == 0 ? G_CONVERTER_FINISHED : G_CONVERTER_CONVERTED;
 }
 
 static void


### PR DESCRIPTION
This partially reverts 20eeebd4b385da1c7165cf3e9d94acd449d7a2bc, but instead moves the success check to after we update bytes_read and bytes_written.

Fixes https://github.com/fwupd/fwupd/issues/7060