### PR TITLE
Fix heap churn by arena allocating temporary nodes during compile stage

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -10,6 +10,7 @@ install_headers(
 )
 
 xb_headers = files(
+  'xb-arena.h',
   'xb-builder.h',
   'xb-builder-fixup.h',
   'xb-builder-node.h',
@@ -64,6 +65,7 @@ def_file_target = custom_target(
 libxmlb = library(
   'xmlb',
   sources : [
+    'xb-arena.c',
     'xb-builder.c',
     'xb-builder-fixup.c',
     'xb-builder-node.c',
@@ -250,6 +252,7 @@ if get_option('tests')
   e = executable(
     'xb-self-test',
     sources : [
+      'xb-arena.c',
       'xb-builder.c',
       'xb-builder-fixup.c',
       'xb-builder-fixup.c',

--- a/src/xb-arena.c
+++ b/src/xb-arena.c
@@ -1,0 +1,182 @@
+/*
+ * Copyright 2025 Owen Chiaventone <ochiaventone@gmail.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#include "xb-arena.h"
+
+#include <glib.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
+
+struct XbArena {
+	size_t n_chunks;
+	size_t chunks_cap;
+	/* Array of pointers to chunks */
+	uint8_t **chunks;
+	/* Points to first free byte in current chunk */
+	uint8_t *tail;
+	uint8_t *current_chunk_end;
+};
+
+XbArena *
+xb_arena_new(void)
+{
+	XbArena *arena = malloc(sizeof(XbArena));
+	*arena = (XbArena){
+	    .n_chunks = 0,
+	    .chunks_cap = 8,
+	    .chunks = (uint8_t **)malloc(8 * sizeof(uint8_t *)),
+	    .tail = NULL,
+	    .current_chunk_end = NULL,
+	};
+	return arena;
+}
+
+static void
+xb_arena_add_chunk(XbArena *arena, uint8_t *chunk)
+{
+	/* Grow chunklist if needed */
+	if (arena->n_chunks + 1 >= arena->chunks_cap) {
+		void *new_chunklist = malloc(arena->chunks_cap * sizeof(uint8_t *) * 2);
+		memcpy(new_chunklist, (void *)arena->chunks, arena->n_chunks * sizeof(uint8_t *));
+		free((void *)arena->chunks);
+		arena->chunks = (uint8_t **)new_chunklist;
+		arena->chunks_cap *= 2;
+	}
+	arena->chunks[arena->n_chunks] = chunk;
+	arena->n_chunks++;
+}
+
+void *
+xb_arena_alloc(XbArena *arena, size_t len)
+{
+	void *alloc = NULL;
+	if (len == 0)
+		return NULL;
+
+	/* Treat allocations larger than a chunk size as their own chunk
+	 * It's not worth trying to optimize those. If this case hits a lot, try
+	 * increasing the arena chunk size. */
+	if (len > XB_ARENA_CHUNKSIZE) {
+		uint8_t *chunk = malloc(len);
+		xb_arena_add_chunk(arena, chunk);
+		/* No need to invalidate tail or current_chunk_end, there's still space
+		in the current chunk for more allocations */
+		return chunk;
+	}
+	/* Round allocations up to nearest whole machine word
+	 * If we didn't do this, allocated structs may cost extra
+	 * to access because of unaligned load/stores and may
+	 * straddle multiple cache lines */
+	len = (len + sizeof(ssize_t) - 1) & ~(sizeof(ssize_t) - 1);
+
+	/* Allocate another chunk if the the requested size won't fit in the current one.
+	 * This will always be hit for the first allocation on a new arena
+	 * because tail and current_chunk_end are initialized to zero. */
+	if (arena->tail + len > arena->current_chunk_end) {
+		uint8_t *chunk = malloc(XB_ARENA_CHUNKSIZE);
+		xb_arena_add_chunk(arena, chunk);
+		arena->tail = chunk;
+		arena->current_chunk_end = chunk + (XB_ARENA_CHUNKSIZE);
+	}
+
+	alloc = arena->tail;
+	arena->tail += len;
+	return alloc;
+}
+
+void
+xb_arena_free(XbArena *arena)
+{
+	for (uint32_t i = 0; i < arena->n_chunks; i++) {
+		free(arena->chunks[i]);
+	}
+	free((void *)arena->chunks);
+	free(arena);
+}
+
+char *
+xb_arena_strdup(XbArena *arena, const char *src)
+{
+	size_t n = 0;
+	char *out = NULL;
+	if (!src)
+		return NULL;
+	n = strlen(src) + 1;
+	out = xb_arena_alloc(arena, n);
+	memcpy(out, src, n);
+	out[n] = '\0';
+	return out;
+}
+
+char *
+xb_arena_strndup(XbArena *arena, const char *src, size_t strsz)
+{
+	size_t n = 0;
+	char *out = NULL;
+	if (!src)
+		return NULL;
+	/* strnlen isn't in the c99/posix standard even though it's widely supported
+	 * easy enough to do it ourselves */
+	for (n = 0; n < strsz; n++) {
+		if (src[n] == '\0')
+			break;
+	}
+	out = xb_arena_alloc(arena, n + 1);
+	memcpy(out, src, n);
+	out[n] = '\0';
+	return out;
+}
+
+XbArenaPtrArray *
+xb_arena_ptr_array_new(XbArena *arena)
+{
+	XbArenaPtrArray *self = xb_arena_alloc(arena, sizeof(XbArenaPtrArray));
+	*self = (XbArenaPtrArray){
+	    .arena = arena,
+	    .pointers = (void **)xb_arena_alloc(arena, 4 * sizeof(void *)),
+	    .len = 0,
+	    .cap = 4,
+	};
+	return self;
+}
+void
+xb_arena_ptr_array_add(XbArenaPtrArray *self, void *data)
+{
+	/* Grow array if necessary */
+	if (self->len + 1 > self->cap) {
+		void *newptrs = NULL;
+		self->cap *= 2;
+		newptrs = xb_arena_alloc(self->arena, self->cap * sizeof(void *));
+		memcpy(newptrs, (void *)self->pointers, self->len * sizeof(void *));
+		self->pointers = (void **)newptrs;
+	}
+	/* Insert new pointer */
+	self->pointers[self->len] = data;
+	self->len++;
+}
+void
+xb_arena_ptr_array_remove(XbArenaPtrArray *self, void *data)
+{
+	for (guint i = 0; i < self->len; i++) {
+		if (self->pointers[i] == data) {
+			xb_arena_ptr_array_remove_index(self, i);
+			return;
+		}
+	}
+}
+
+void
+xb_arena_ptr_array_remove_index(XbArenaPtrArray *self, size_t index)
+{
+	/* Must preserve order of elements. Slide down all elements after the removed one */
+    for (guint i = index; i < self->len - 1; i++) {
+        self->pointers[i] = self->pointers[i+1];
+    }
+    self->len--;
+}

--- a/src/xb-arena.h
+++ b/src/xb-arena.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2025 Owen Chiaventone <ochiaventone@gmail.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#pragma once
+
+/* Simple arena allocator used to construct nodes during parsing pass
+ * If the nodes and strings on them were individually heap allocated instead, we would churn the
+ * heap with a large number of small and medium sized allocations. This is bad for performance in
+ * a short lived program, but more importantly can trigger serious heap fragmentation if you parse
+ * a large XML in the middle of a long-lived program.
+ * This was implicated in https://gitlab.gnome.org/GNOME/gnome-software/-/issues/941
+ *
+ * We don't know how large the XML is when we start parsing, so the arena may have to grow.
+ * This arena allocator uses a chunking strategy - if we run out, allocate another large block.
+ *
+ * This arena is *not* threadsafe. It is expected that it will be created and used from a single
+ * thread. Making the arena threadsafe would signficantly change its performance characteristics
+ */
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+/* default to 1MB chunks for arena allocation.
+ * Most allocators have heuristics to optimize large allocations
+ * For example with glibc malloc this should be above DEFAULT_MMAP_THRESHOLD
+ * see  https://sourceware.org/glibc/wiki/MallocInternals */
+#define XB_ARENA_CHUNKSIZE 1 << 20
+
+typedef struct XbArena XbArena;
+
+XbArena *
+xb_arena_new(void);
+
+/* Allocate bytes from the arena */
+void *
+xb_arena_alloc(XbArena *arena, size_t len);
+
+/* Free the entire arena at once. Deactivates the arena object. */
+void
+xb_arena_free(XbArena *arena);
+
+/*
+ * Arena friendly alternatives for GLib data structures
+ */
+char *
+xb_arena_strdup(XbArena *arena, const char *src);
+char *
+xb_arena_strndup(XbArena *arena, const char *src, size_t strsz);
+
+typedef struct XbArenaPtrArray {
+	XbArena *arena;
+	void **pointers;
+	size_t len;
+	size_t cap;
+} XbArenaPtrArray;
+
+XbArenaPtrArray *
+xb_arena_ptr_array_new(XbArena *arena);
+void
+xb_arena_ptr_array_add(XbArenaPtrArray *self, void *data);
+void
+xb_arena_ptr_array_remove(XbArenaPtrArray *self, void *data);
+void
+xb_arena_ptr_array_remove_index(XbArenaPtrArray *self, size_t index);

--- a/src/xb-builder-node-private.h
+++ b/src/xb-builder-node-private.h
@@ -19,7 +19,7 @@ typedef struct {
 	guint32 value_idx;
 } XbBuilderNodeAttr;
 
-GPtrArray *
+XbArenaPtrArray *
 xb_builder_node_get_attrs(XbBuilderNode *self) G_GNUC_NON_NULL(1);
 guint32
 xb_builder_node_size(XbBuilderNode *self) G_GNUC_NON_NULL(1);

--- a/src/xb-builder-node.c
+++ b/src/xb-builder-node.c
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later
  */
 
+#include "glib.h"
 #define G_LOG_DOMAIN "XbSilo"
 
 #include "config.h"
@@ -16,7 +17,7 @@
 #include "xb-silo-private.h"
 #include "xb-string-private.h"
 
-typedef struct {
+struct XbBuilderNode {
 	guint32 offset;
 	gint priority;
 	XbBuilderNodeFlags flags;
@@ -39,12 +40,7 @@ typedef struct {
 	/* Most nodes will have no tokens */
 	GPtrArray *tokens;  /* (element-type utf8) (nullable) */
 	GArray *token_idxs; /* (element-type guint32) (nullable) */
-
-} XbBuilderNodePrivate;
-
-G_DEFINE_TYPE_WITH_PRIVATE(XbBuilderNode, xb_builder_node, G_TYPE_OBJECT)
-#define GET_PRIVATE(o) (xb_builder_node_get_instance_private(o))
-
+};
 static void
 xb_builder_node_attr_free(XbBuilderNodeAttr *attr);
 
@@ -62,9 +58,7 @@ xb_builder_node_attr_free(XbBuilderNodeAttr *attr);
 gboolean
 xb_builder_node_has_flag(XbBuilderNode *self, XbBuilderNodeFlags flag)
 {
-	XbBuilderNodePrivate *priv = GET_PRIVATE(self);
-	g_return_val_if_fail(XB_IS_BUILDER_NODE(self), FALSE);
-	return (priv->flags & flag) > 0;
+	return (self->flags & flag) > 0;
 }
 
 /**
@@ -79,19 +73,16 @@ xb_builder_node_has_flag(XbBuilderNode *self, XbBuilderNodeFlags flag)
 void
 xb_builder_node_add_flag(XbBuilderNode *self, XbBuilderNodeFlags flag)
 {
-	XbBuilderNodePrivate *priv = GET_PRIVATE(self);
-	g_return_if_fail(XB_IS_BUILDER_NODE(self));
-
-	if ((priv->flags & flag) != 0)
+	if ((self->flags & flag) != 0)
 		return;
 
 	/* do in-place */
-	if ((flag & XB_BUILDER_NODE_FLAG_STRIP_TEXT) > 0 && priv->text != NULL)
-		g_strstrip(priv->text);
+	if ((flag & XB_BUILDER_NODE_FLAG_STRIP_TEXT) > 0 && self->text != NULL)
+		g_strstrip(self->text);
 
-	priv->flags |= flag;
-	for (guint i = 0; priv->children != NULL && i < priv->children->len; i++) {
-		XbBuilderNode *c = g_ptr_array_index(priv->children, i);
+	self->flags |= flag;
+	for (guint i = 0; self->children != NULL && i < self->children->len; i++) {
+		XbBuilderNode *c = g_ptr_array_index(self->children, i);
 		xb_builder_node_add_flag(c, flag);
 	}
 }
@@ -109,9 +100,7 @@ xb_builder_node_add_flag(XbBuilderNode *self, XbBuilderNodeFlags flag)
 const gchar *
 xb_builder_node_get_element(XbBuilderNode *self)
 {
-	XbBuilderNodePrivate *priv = GET_PRIVATE(self);
-	g_return_val_if_fail(XB_IS_BUILDER_NODE(self), NULL);
-	return priv->element;
+	return self->element;
 }
 
 /**
@@ -126,10 +115,8 @@ xb_builder_node_get_element(XbBuilderNode *self)
 void
 xb_builder_node_set_element(XbBuilderNode *self, const gchar *element)
 {
-	XbBuilderNodePrivate *priv = GET_PRIVATE(self);
-	g_return_if_fail(XB_IS_BUILDER_NODE(self));
-	g_free(priv->element);
-	priv->element = g_strdup(element);
+	g_free(self->element);
+	self->element = g_strdup(element);
 }
 
 /**
@@ -146,15 +133,13 @@ xb_builder_node_set_element(XbBuilderNode *self, const gchar *element)
 const gchar *
 xb_builder_node_get_attr(XbBuilderNode *self, const gchar *name)
 {
-	XbBuilderNodePrivate *priv = GET_PRIVATE(self);
-	g_return_val_if_fail(XB_IS_BUILDER_NODE(self), NULL);
 	g_return_val_if_fail(name != NULL, NULL);
 
-	if (priv->attrs == NULL)
+	if (self->attrs == NULL)
 		return NULL;
 
-	for (guint i = 0; i < priv->attrs->len; i++) {
-		XbBuilderNodeAttr *a = g_ptr_array_index(priv->attrs, i);
+	for (guint i = 0; i < self->attrs->len; i++) {
+		XbBuilderNodeAttr *a = g_ptr_array_index(self->attrs, i);
 		if (g_strcmp0(a->name, name) == 0)
 			return a->value;
 	}
@@ -196,9 +181,7 @@ xb_builder_node_get_attr_as_uint(XbBuilderNode *self, const gchar *name)
 const gchar *
 xb_builder_node_get_text(XbBuilderNode *self)
 {
-	XbBuilderNodePrivate *priv = GET_PRIVATE(self);
-	g_return_val_if_fail(XB_IS_BUILDER_NODE(self), NULL);
-	return priv->text;
+	return self->text;
 }
 
 /**
@@ -235,9 +218,7 @@ xb_builder_node_get_text_as_uint(XbBuilderNode *self)
 const gchar *
 xb_builder_node_get_tail(XbBuilderNode *self)
 {
-	XbBuilderNodePrivate *priv = GET_PRIVATE(self);
-	g_return_val_if_fail(XB_IS_BUILDER_NODE(self), NULL);
-	return priv->tail;
+	return self->tail;
 }
 
 /* private */
@@ -245,9 +226,7 @@ xb_builder_node_get_tail(XbBuilderNode *self)
 GPtrArray *
 xb_builder_node_get_attrs(XbBuilderNode *self)
 {
-	XbBuilderNodePrivate *priv = GET_PRIVATE(self);
-	g_return_val_if_fail(XB_IS_BUILDER_NODE(self), NULL);
-	return priv->attrs;
+	return self->attrs;
 }
 
 static gchar *
@@ -332,24 +311,21 @@ xb_builder_node_parse_literal_text(XbBuilderNode *self, const gchar *text, gssiz
 void
 xb_builder_node_tokenize_text(XbBuilderNode *self)
 {
-	XbBuilderNodePrivate *priv = GET_PRIVATE(self);
 	const gchar *xml_lang = xb_builder_node_get_attr(self, "xml:lang");
 	guint ascii_tokens_sz;
 	guint tokens_sz;
 	g_autofree gchar **ascii_tokens = NULL;
 	g_autofree gchar **tokens = NULL;
 
-	g_return_if_fail(XB_IS_BUILDER_NODE(self));
-
-	if (priv->text == NULL)
+	if (self->text == NULL)
 		return;
-	tokens = g_str_tokenize_and_fold(priv->text, xml_lang, &ascii_tokens);
+	tokens = g_str_tokenize_and_fold(self->text, xml_lang, &ascii_tokens);
 
 	/* preallocate the right array size (and more for invalid tokens) */
 	tokens_sz = g_strv_length(tokens);
 	ascii_tokens_sz = g_strv_length(ascii_tokens);
-	if (priv->tokens == NULL)
-		priv->tokens = g_ptr_array_new_full(tokens_sz + ascii_tokens_sz, g_free);
+	if (self->tokens == NULL)
+		self->tokens = g_ptr_array_new_full(tokens_sz + ascii_tokens_sz, g_free);
 
 	/* add all valid UTF-8 and ASCII tokens */
 	for (guint i = 0; i < tokens_sz; i++) {
@@ -357,14 +333,14 @@ xb_builder_node_tokenize_text(XbBuilderNode *self)
 			g_free(g_steal_pointer(&tokens[i]));
 			continue;
 		}
-		g_ptr_array_add(priv->tokens, g_steal_pointer(&tokens[i]));
+		g_ptr_array_add(self->tokens, g_steal_pointer(&tokens[i]));
 	}
 	for (guint i = 0; i < ascii_tokens_sz; i++) {
 		if (!xb_string_token_valid(ascii_tokens[i])) {
 			g_free(g_steal_pointer(&ascii_tokens[i]));
 			continue;
 		}
-		g_ptr_array_add(priv->tokens, g_steal_pointer(&ascii_tokens[i]));
+		g_ptr_array_add(self->tokens, g_steal_pointer(&ascii_tokens[i]));
 	}
 
 	/* add this so we can set XbSiloNodeFlag.TOKENIZE_TEXT */
@@ -384,21 +360,17 @@ xb_builder_node_tokenize_text(XbBuilderNode *self)
 void
 xb_builder_node_set_text(XbBuilderNode *self, const gchar *text, gssize text_len)
 {
-	XbBuilderNodePrivate *priv = GET_PRIVATE(self);
-
-	g_return_if_fail(XB_IS_BUILDER_NODE(self));
-
 	/* old data */
-	g_free(priv->text);
-	priv->text = xb_builder_node_parse_literal_text(self, text, text_len);
-	priv->flags |= XB_BUILDER_NODE_FLAG_HAS_TEXT;
+	g_free(self->text);
+	self->text = xb_builder_node_parse_literal_text(self, text, text_len);
+	self->flags |= XB_BUILDER_NODE_FLAG_HAS_TEXT;
 
 	/* strip before tokenization */
-	if ((priv->flags & XB_BUILDER_NODE_FLAG_STRIP_TEXT) > 0 && priv->text != NULL)
-		g_strstrip(priv->text);
+	if ((self->flags & XB_BUILDER_NODE_FLAG_STRIP_TEXT) > 0 && self->text != NULL)
+		g_strstrip(self->text);
 
 	/* tokenize */
-	if (priv->flags & XB_BUILDER_NODE_FLAG_TOKENIZE_TEXT)
+	if (self->flags & XB_BUILDER_NODE_FLAG_TOKENIZE_TEXT)
 		xb_builder_node_tokenize_text(self);
 }
 
@@ -415,14 +387,10 @@ xb_builder_node_set_text(XbBuilderNode *self, const gchar *text, gssize text_len
 void
 xb_builder_node_set_tail(XbBuilderNode *self, const gchar *tail, gssize tail_len)
 {
-	XbBuilderNodePrivate *priv = GET_PRIVATE(self);
-
-	g_return_if_fail(XB_IS_BUILDER_NODE(self));
-
 	/* old data */
-	g_free(priv->tail);
-	priv->tail = xb_builder_node_parse_literal_text(self, tail, tail_len);
-	priv->flags |= XB_BUILDER_NODE_FLAG_HAS_TAIL;
+	g_free(self->tail);
+	self->tail = xb_builder_node_parse_literal_text(self, tail, tail_len);
+	self->flags |= XB_BUILDER_NODE_FLAG_HAS_TAIL;
 }
 
 /**
@@ -439,18 +407,16 @@ void
 xb_builder_node_set_attr(XbBuilderNode *self, const gchar *name, const gchar *value)
 {
 	XbBuilderNodeAttr *a;
-	XbBuilderNodePrivate *priv = GET_PRIVATE(self);
 
-	g_return_if_fail(XB_IS_BUILDER_NODE(self));
 	g_return_if_fail(name != NULL);
 
-	if (priv->attrs == NULL)
-		priv->attrs =
+	if (self->attrs == NULL)
+		self->attrs =
 		    g_ptr_array_new_with_free_func((GDestroyNotify)xb_builder_node_attr_free);
 
 	/* check for existing name */
-	for (guint i = 0; i < priv->attrs->len; i++) {
-		a = g_ptr_array_index(priv->attrs, i);
+	for (guint i = 0; i < self->attrs->len; i++) {
+		a = g_ptr_array_index(self->attrs, i);
 		if (g_strcmp0(a->name, name) == 0) {
 			g_free(a->value);
 			a->value = g_strdup(value);
@@ -464,7 +430,7 @@ xb_builder_node_set_attr(XbBuilderNode *self, const gchar *name, const gchar *va
 	a->name_idx = XB_SILO_UNSET;
 	a->value = g_strdup(value);
 	a->value_idx = XB_SILO_UNSET;
-	g_ptr_array_add(priv->attrs, a);
+	g_ptr_array_add(self->attrs, a);
 }
 
 /**
@@ -479,18 +445,15 @@ xb_builder_node_set_attr(XbBuilderNode *self, const gchar *name, const gchar *va
 void
 xb_builder_node_remove_attr(XbBuilderNode *self, const gchar *name)
 {
-	XbBuilderNodePrivate *priv = GET_PRIVATE(self);
-
-	g_return_if_fail(XB_IS_BUILDER_NODE(self));
 	g_return_if_fail(name != NULL);
 
-	if (priv->attrs == NULL)
+	if (self->attrs == NULL)
 		return;
 
-	for (guint i = 0; i < priv->attrs->len; i++) {
-		XbBuilderNodeAttr *a = g_ptr_array_index(priv->attrs, i);
+	for (guint i = 0; i < self->attrs->len; i++) {
+		XbBuilderNodeAttr *a = g_ptr_array_index(self->attrs, i);
 		if (g_strcmp0(a->name, name) == 0) {
-			g_ptr_array_remove_index(priv->attrs, i);
+			g_ptr_array_remove_index(self->attrs, i);
 			break;
 		}
 	}
@@ -508,10 +471,9 @@ guint
 xb_builder_node_depth(XbBuilderNode *self)
 {
 	for (guint i = 0;; i++) {
-		XbBuilderNodePrivate *priv = GET_PRIVATE(self);
-		if (priv->parent == NULL)
+		if (self->parent == NULL)
 			return i;
-		self = priv->parent;
+		self = self->parent;
 	}
 	return 0;
 }
@@ -528,19 +490,13 @@ xb_builder_node_depth(XbBuilderNode *self)
 void
 xb_builder_node_add_child(XbBuilderNode *self, XbBuilderNode *child)
 {
-	XbBuilderNodePrivate *priv = GET_PRIVATE(self);
-	XbBuilderNodePrivate *priv_child = GET_PRIVATE(child);
-	g_return_if_fail(XB_IS_BUILDER_NODE(self));
-	g_return_if_fail(XB_IS_BUILDER_NODE(child));
-	g_return_if_fail(priv_child->parent == NULL);
+	g_return_if_fail(child->parent == NULL);
+	child->parent = self;
 
-	/* no refcount */
-	priv_child->parent = self;
+	if (self->children == NULL)
+		self->children = g_ptr_array_new_with_free_func(NULL);
 
-	if (priv->children == NULL)
-		priv->children = g_ptr_array_new_with_free_func((GDestroyNotify)g_object_unref);
-
-	g_ptr_array_add(priv->children, g_object_ref(child));
+	g_ptr_array_add(self->children, child);
 }
 
 /**
@@ -555,14 +511,10 @@ xb_builder_node_add_child(XbBuilderNode *self, XbBuilderNode *child)
 void
 xb_builder_node_remove_child(XbBuilderNode *self, XbBuilderNode *child)
 {
-	XbBuilderNodePrivate *priv = GET_PRIVATE(self);
-	XbBuilderNodePrivate *priv_child = GET_PRIVATE(child);
+	child->parent = NULL;
 
-	/* no refcount */
-	priv_child->parent = NULL;
-
-	if (priv->children != NULL)
-		g_ptr_array_remove(priv->children, child);
+	if (self->children != NULL)
+		g_ptr_array_remove(self->children, child);
 }
 
 /**
@@ -581,11 +533,9 @@ xb_builder_node_remove_child(XbBuilderNode *self, XbBuilderNode *child)
 void
 xb_builder_node_unlink(XbBuilderNode *self)
 {
-	XbBuilderNodePrivate *priv = GET_PRIVATE(self);
-	g_return_if_fail(XB_IS_BUILDER_NODE(self));
-	if (priv->parent == NULL)
+	if (self->parent == NULL)
 		return;
-	xb_builder_node_remove_child(priv->parent, self);
+	xb_builder_node_remove_child(self->parent, self);
 }
 
 /**
@@ -601,11 +551,7 @@ xb_builder_node_unlink(XbBuilderNode *self)
 XbBuilderNode *
 xb_builder_node_get_parent(XbBuilderNode *self)
 {
-	XbBuilderNodePrivate *priv = GET_PRIVATE(self);
-	g_return_val_if_fail(XB_IS_BUILDER_NODE(self), NULL);
-	if (priv->parent == NULL)
-		return NULL;
-	return g_object_ref(priv->parent);
+	return self->parent;
 }
 
 /**
@@ -621,15 +567,12 @@ xb_builder_node_get_parent(XbBuilderNode *self)
 GPtrArray *
 xb_builder_node_get_children(XbBuilderNode *self)
 {
-	XbBuilderNodePrivate *priv = GET_PRIVATE(self);
-	g_return_val_if_fail(XB_IS_BUILDER_NODE(self), NULL);
-
 	/* For backwards compatibility reasons we have to return a non-%NULL
 	 * array here. */
-	if (priv->children == NULL)
-		priv->children = g_ptr_array_new_with_free_func((GDestroyNotify)g_object_unref);
+	if (self->children == NULL)
+		self->children = g_ptr_array_new_with_free_func(NULL);
 
-	return priv->children;
+	return self->children;
 }
 
 /**
@@ -645,11 +588,9 @@ xb_builder_node_get_children(XbBuilderNode *self)
 XbBuilderNode *
 xb_builder_node_get_first_child(XbBuilderNode *self)
 {
-	XbBuilderNodePrivate *priv = GET_PRIVATE(self);
-	g_return_val_if_fail(XB_IS_BUILDER_NODE(self), NULL);
-	if (priv->children == NULL || priv->children->len == 0)
+	if (self->children == NULL || self->children->len == 0)
 		return NULL;
-	return g_ptr_array_index(priv->children, 0);
+	return g_ptr_array_index(self->children, 0);
 }
 
 /**
@@ -665,11 +606,9 @@ xb_builder_node_get_first_child(XbBuilderNode *self)
 XbBuilderNode *
 xb_builder_node_get_last_child(XbBuilderNode *self)
 {
-	XbBuilderNodePrivate *priv = GET_PRIVATE(self);
-	g_return_val_if_fail(XB_IS_BUILDER_NODE(self), NULL);
-	if (priv->children == NULL || priv->children->len == 0)
+	if (self->children == NULL || self->children->len == 0)
 		return NULL;
-	return g_ptr_array_index(priv->children, priv->children->len - 1);
+	return g_ptr_array_index(self->children, self->children->len - 1);
 }
 
 /**
@@ -687,21 +626,18 @@ xb_builder_node_get_last_child(XbBuilderNode *self)
 XbBuilderNode *
 xb_builder_node_get_child(XbBuilderNode *self, const gchar *element, const gchar *text)
 {
-	XbBuilderNodePrivate *priv = GET_PRIVATE(self);
-
-	g_return_val_if_fail(XB_IS_BUILDER_NODE(self), NULL);
 	g_return_val_if_fail(element != NULL, NULL);
 
-	if (priv->children == NULL)
+	if (self->children == NULL)
 		return NULL;
 
-	for (guint i = 0; i < priv->children->len; i++) {
-		XbBuilderNode *child = g_ptr_array_index(priv->children, i);
+	for (guint i = 0; i < self->children->len; i++) {
+		XbBuilderNode *child = g_ptr_array_index(self->children, i);
 		if (g_strcmp0(xb_builder_node_get_element(child), element) != 0)
 			continue;
 		if (text != NULL && g_strcmp0(xb_builder_node_get_text(child), text) != 0)
 			continue;
-		return g_object_ref(child);
+		return child;
 	}
 	return NULL;
 }
@@ -717,8 +653,7 @@ typedef struct {
 static void
 xb_builder_node_traverse_cb(XbBuilderNodeTraverseHelper *helper, XbBuilderNode *bn, gint depth)
 {
-	XbBuilderNodePrivate *priv = GET_PRIVATE(bn);
-	GPtrArray *children = priv->children;
+	GPtrArray *children = bn->children;
 
 	/* only leaves */
 	if (helper->flags == G_TRAVERSE_LEAVES && children != NULL && children->len > 0)
@@ -810,118 +745,95 @@ xb_builder_node_sort_children_cb(gconstpointer a, gconstpointer b, gpointer user
 void
 xb_builder_node_sort_children(XbBuilderNode *self, XbBuilderNodeSortFunc func, gpointer user_data)
 {
-	XbBuilderNodePrivate *priv = GET_PRIVATE(self);
 	XbBuilderNodeSortHelper helper = {
 	    .func = func,
 	    .user_data = user_data,
 	};
-	g_return_if_fail(XB_IS_BUILDER_NODE(self));
 	g_return_if_fail(func != NULL);
 
-	if (priv->children == NULL)
+	if (self->children == NULL)
 		return;
 
-	g_ptr_array_sort_with_data(priv->children, xb_builder_node_sort_children_cb, &helper);
+	g_ptr_array_sort_with_data(self->children, xb_builder_node_sort_children_cb, &helper);
 }
 
 /* private */
 guint32
 xb_builder_node_get_offset(XbBuilderNode *self)
 {
-	XbBuilderNodePrivate *priv = GET_PRIVATE(self);
-	g_return_val_if_fail(XB_IS_BUILDER_NODE(self), 0);
-	return priv->offset;
+	return self->offset;
 }
 
 /* private */
 void
 xb_builder_node_set_offset(XbBuilderNode *self, guint32 offset)
 {
-	XbBuilderNodePrivate *priv = GET_PRIVATE(self);
-	g_return_if_fail(XB_IS_BUILDER_NODE(self));
-	priv->offset = offset;
+	self->offset = offset;
 }
 
 /* private */
 gint
 xb_builder_node_get_priority(XbBuilderNode *self)
 {
-	XbBuilderNodePrivate *priv = GET_PRIVATE(self);
-	g_return_val_if_fail(XB_IS_BUILDER_NODE(self), 0);
-	return priv->priority;
+	return self->priority;
 }
 
 /* private */
 void
 xb_builder_node_set_priority(XbBuilderNode *self, gint priority)
 {
-	XbBuilderNodePrivate *priv = GET_PRIVATE(self);
-	g_return_if_fail(XB_IS_BUILDER_NODE(self));
-	priv->priority = priority;
+	self->priority = priority;
 }
 
 /* private */
 guint32
 xb_builder_node_get_element_idx(XbBuilderNode *self)
 {
-	XbBuilderNodePrivate *priv = GET_PRIVATE(self);
-	g_return_val_if_fail(XB_IS_BUILDER_NODE(self), 0);
-	return priv->element_idx;
+	return self->element_idx;
 }
 
 /* private */
 void
 xb_builder_node_set_element_idx(XbBuilderNode *self, guint32 element_idx)
 {
-	XbBuilderNodePrivate *priv = GET_PRIVATE(self);
-	g_return_if_fail(XB_IS_BUILDER_NODE(self));
-	priv->element_idx = element_idx;
+	self->element_idx = element_idx;
 }
 
 /* private */
 guint32
 xb_builder_node_get_text_idx(XbBuilderNode *self)
 {
-	XbBuilderNodePrivate *priv = GET_PRIVATE(self);
-	g_return_val_if_fail(XB_IS_BUILDER_NODE(self), 0);
-	return priv->text_idx;
+	return self->text_idx;
 }
 
 /* private */
 void
 xb_builder_node_set_text_idx(XbBuilderNode *self, guint32 text_idx)
 {
-	XbBuilderNodePrivate *priv = GET_PRIVATE(self);
-	g_return_if_fail(XB_IS_BUILDER_NODE(self));
-	priv->text_idx = text_idx;
+	self->text_idx = text_idx;
 }
 
 /* private */
 guint32
 xb_builder_node_get_tail_idx(XbBuilderNode *self)
 {
-	XbBuilderNodePrivate *priv = GET_PRIVATE(self);
-	g_return_val_if_fail(XB_IS_BUILDER_NODE(self), 0);
-	return priv->tail_idx;
+	return self->tail_idx;
 }
 
 /* private */
 void
 xb_builder_node_set_tail_idx(XbBuilderNode *self, guint32 tail_idx)
 {
-	XbBuilderNodePrivate *priv = GET_PRIVATE(self);
-	g_return_if_fail(XB_IS_BUILDER_NODE(self));
-	priv->tail_idx = tail_idx;
+	self->tail_idx = tail_idx;
 }
 
 /* private */
 guint32
 xb_builder_node_size(XbBuilderNode *self)
 {
-	XbBuilderNodePrivate *priv = GET_PRIVATE(self);
 	guint32 sz = sizeof(XbSiloNode);
-	gsize attr_len = (priv->attrs != NULL) ? priv->attrs->len : 0;
-	gsize token_len = (priv->tokens != NULL) ? MIN(priv->tokens->len, XB_OPCODE_TOKEN_MAX) : 0;
+	gsize attr_len = (self->attrs != NULL) ? self->attrs->len : 0;
+	gsize token_len = (self->tokens != NULL) ? MIN(self->tokens->len, XB_OPCODE_TOKEN_MAX) : 0;
 	return sz + attr_len * sizeof(XbSiloNodeAttr) + token_len * sizeof(guint32);
 }
 
@@ -936,55 +848,13 @@ xb_builder_node_attr_free(XbBuilderNodeAttr *attr)
 static void
 xb_builder_node_init(XbBuilderNode *self)
 {
-	XbBuilderNodePrivate *priv = GET_PRIVATE(self);
-	priv->element_idx = XB_SILO_UNSET;
-	priv->text_idx = XB_SILO_UNSET;
-	priv->tail_idx = XB_SILO_UNSET;
-	priv->attrs = NULL;    /* only allocated when an attribute is added */
-	priv->children = NULL; /* only allocated when a child is added */
+	self->element_idx = XB_SILO_UNSET;
+	self->text_idx = XB_SILO_UNSET;
+	self->tail_idx = XB_SILO_UNSET;
+	self->attrs = NULL;    /* only allocated when an attribute is added */
+	self->children = NULL; /* only allocated when a child is added */
 }
 
-static void
-xb_builder_node_dispose(GObject *obj)
-{
-	XbBuilderNode *self = XB_BUILDER_NODE(obj);
-	XbBuilderNodePrivate *priv = GET_PRIVATE(self);
-
-	/* clear all the child nodes’ parent pointers */
-	if (priv->children != NULL) {
-		for (guint i = 0; i < priv->children->len; i++) {
-			XbBuilderNode *child = g_ptr_array_index(priv->children, i);
-			XbBuilderNodePrivate *priv_child = GET_PRIVATE(child);
-			priv_child->parent = NULL;
-		}
-	}
-
-	G_OBJECT_CLASS(xb_builder_node_parent_class)->dispose(obj);
-}
-
-static void
-xb_builder_node_finalize(GObject *obj)
-{
-	XbBuilderNode *self = XB_BUILDER_NODE(obj);
-	XbBuilderNodePrivate *priv = GET_PRIVATE(self);
-	g_free(priv->element);
-	g_free(priv->text);
-	g_free(priv->tail);
-	g_clear_pointer(&priv->attrs, g_ptr_array_unref);
-	g_clear_pointer(&priv->children, g_ptr_array_unref);
-	g_clear_pointer(&priv->tokens, g_ptr_array_unref);
-	g_clear_pointer(&priv->token_idxs, g_array_unref);
-	G_OBJECT_CLASS(xb_builder_node_parent_class)->finalize(obj);
-}
-
-static void
-xb_builder_node_class_init(XbBuilderNodeClass *klass)
-{
-	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-
-	object_class->dispose = xb_builder_node_dispose;
-	object_class->finalize = xb_builder_node_finalize;
-}
 
 /**
  * xb_builder_node_new:
@@ -999,9 +869,15 @@ xb_builder_node_class_init(XbBuilderNodeClass *klass)
 XbBuilderNode *
 xb_builder_node_new(const gchar *element)
 {
-	XbBuilderNode *self = g_object_new(XB_TYPE_BUILDER_NODE, NULL);
-	XbBuilderNodePrivate *priv = GET_PRIVATE(self);
-	priv->element = g_strdup(element);
+	XbBuilderNode *self = malloc(sizeof(XbBuilderNode));
+	*self = (XbBuilderNode){
+	    .element = g_strdup(element),
+	    .element_idx = XB_SILO_UNSET,
+	    .text_idx = XB_SILO_UNSET,
+	    .tail_idx = XB_SILO_UNSET,
+	    .attrs = NULL,    /* only allocated when an attribute is added */
+	    .children = NULL, /* only allocated when a child is added */
+	};
 	return self;
 }
 
@@ -1059,7 +935,7 @@ xb_builder_node_insert(XbBuilderNode *parent, const gchar *element, ...)
 void
 xb_builder_node_insert_text(XbBuilderNode *parent, const gchar *element, const gchar *text, ...)
 {
-	g_autoptr(XbBuilderNode) self = xb_builder_node_new(element);
+	XbBuilderNode *self = xb_builder_node_new(element);
 	va_list args;
 	const gchar *key;
 	const gchar *value;
@@ -1096,7 +972,6 @@ xb_builder_node_export_helper(XbBuilderNode *self,
 			      XbBuilderNodeExportHelper *helper,
 			      GError **error)
 {
-	XbBuilderNodePrivate *priv = GET_PRIVATE(self);
 
 	/* do not output */
 	if (xb_builder_node_has_flag(self, XB_BUILDER_NODE_FLAG_IGNORE))
@@ -1107,23 +982,23 @@ xb_builder_node_export_helper(XbBuilderNode *self,
 		for (guint i = 0; i < helper->level; i++)
 			g_string_append(helper->xml, "  ");
 	}
-	g_string_append_printf(helper->xml, "<%s", priv->element);
+	g_string_append_printf(helper->xml, "<%s", self->element);
 
 	/* add any attributes */
-	for (guint i = 0; priv->attrs != NULL && i < priv->attrs->len; i++) {
-		XbBuilderNodeAttr *a = g_ptr_array_index(priv->attrs, i);
+	for (guint i = 0; self->attrs != NULL && i < self->attrs->len; i++) {
+		XbBuilderNodeAttr *a = g_ptr_array_index(self->attrs, i);
 		g_autofree gchar *key = xb_string_xml_escape(a->name);
 		g_autofree gchar *val = xb_string_xml_escape(a->value);
 		g_string_append_printf(helper->xml, " %s=\"%s\"", key, val);
 	}
 
-	if (helper->flags & XB_NODE_EXPORT_FLAG_COLLAPSE_EMPTY && priv->text == NULL &&
-	    priv->children == NULL) {
+	if (helper->flags & XB_NODE_EXPORT_FLAG_COLLAPSE_EMPTY && self->text == NULL &&
+	    self->children == NULL) {
 		g_string_append(helper->xml, " />");
 	} else {
 		/* finish the opening tag and add any text if it exists */
-		if (priv->text != NULL) {
-			g_autofree gchar *text = xb_string_xml_escape(priv->text);
+		if (self->text != NULL) {
+			g_autofree gchar *text = xb_string_xml_escape(self->text);
 			g_string_append(helper->xml, ">");
 			g_string_append(helper->xml, text);
 		} else {
@@ -1133,8 +1008,8 @@ xb_builder_node_export_helper(XbBuilderNode *self,
 		}
 
 		/* recurse deeper */
-		for (guint i = 0; priv->children != NULL && i < priv->children->len; i++) {
-			XbBuilderNode *child = g_ptr_array_index(priv->children, i);
+		for (guint i = 0; self->children != NULL && i < self->children->len; i++) {
+			XbBuilderNode *child = g_ptr_array_index(self->children, i);
 			helper->level++;
 			if (!xb_builder_node_export_helper(child, helper, error))
 				return FALSE;
@@ -1142,16 +1017,16 @@ xb_builder_node_export_helper(XbBuilderNode *self,
 		}
 
 		/* add closing tag */
-		if ((helper->flags & XB_NODE_EXPORT_FLAG_FORMAT_INDENT) > 0 && priv->text == NULL) {
+		if ((helper->flags & XB_NODE_EXPORT_FLAG_FORMAT_INDENT) > 0 && self->text == NULL) {
 			for (guint i = 0; i < helper->level; i++)
 				g_string_append(helper->xml, "  ");
 		}
-		g_string_append_printf(helper->xml, "</%s>", priv->element);
+		g_string_append_printf(helper->xml, "</%s>", self->element);
 	}
 
 	/* add any tail if it exists */
-	if (priv->tail != NULL) {
-		g_autofree gchar *tail = xb_string_xml_escape(priv->tail);
+	if (self->tail != NULL) {
+		g_autofree gchar *tail = xb_string_xml_escape(self->tail);
 		g_string_append(helper->xml, tail);
 	}
 
@@ -1181,7 +1056,6 @@ xb_builder_node_export(XbBuilderNode *self, XbNodeExportFlags flags, GError **er
 	    .level = 0,
 	    .xml = xml,
 	};
-	g_return_val_if_fail(XB_IS_BUILDER_NODE(self), NULL);
 	g_return_val_if_fail(error == NULL || *error == NULL, NULL);
 	if ((flags & XB_NODE_EXPORT_FLAG_ADD_HEADER) > 0)
 		g_string_append(xml, "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
@@ -1202,14 +1076,13 @@ xb_builder_node_export(XbBuilderNode *self, XbNodeExportFlags flags, GError **er
 void
 xb_builder_node_add_token(XbBuilderNode *self, const gchar *token)
 {
-	XbBuilderNodePrivate *priv = GET_PRIVATE(self);
 
 	g_return_if_fail(self != NULL);
 	g_return_if_fail(token != NULL);
 
-	if (priv->tokens == NULL)
-		priv->tokens = g_ptr_array_new_with_free_func(g_free);
-	g_ptr_array_add(priv->tokens, g_strdup(token));
+	if (self->tokens == NULL)
+		self->tokens = g_ptr_array_new_with_free_func(g_free);
+	g_ptr_array_add(self->tokens, g_strdup(token));
 }
 
 /**
@@ -1225,30 +1098,27 @@ xb_builder_node_add_token(XbBuilderNode *self, const gchar *token)
 GPtrArray *
 xb_builder_node_get_tokens(XbBuilderNode *self)
 {
-	XbBuilderNodePrivate *priv = GET_PRIVATE(self);
 	g_return_val_if_fail(self != NULL, NULL);
-	return priv->tokens;
+	return self->tokens;
 }
 
 /* private */
 void
 xb_builder_node_add_token_idx(XbBuilderNode *self, guint32 tail_idx)
 {
-	XbBuilderNodePrivate *priv = GET_PRIVATE(self);
 
 	g_return_if_fail(self != NULL);
 	g_return_if_fail(tail_idx != XB_SILO_UNSET);
 
-	if (priv->token_idxs == NULL)
-		priv->token_idxs = g_array_new(FALSE, FALSE, sizeof(guint32));
-	g_array_append_val(priv->token_idxs, tail_idx);
+	if (self->token_idxs == NULL)
+		self->token_idxs = g_array_new(FALSE, FALSE, sizeof(guint32));
+	g_array_append_val(self->token_idxs, tail_idx);
 }
 
 /* Returns: (transfer none) (element-type guint32) (nullable): token indexes */
 GArray *
 xb_builder_node_get_token_idxs(XbBuilderNode *self)
 {
-	XbBuilderNodePrivate *priv = GET_PRIVATE(self);
 	g_return_val_if_fail(self != NULL, NULL);
-	return priv->token_idxs;
+	return self->token_idxs;
 }

--- a/src/xb-builder-node.h
+++ b/src/xb-builder-node.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include "xb-arena.h"
 #include "xb-compile.h"
 #include "xb-node.h"
 
@@ -46,11 +47,10 @@ typedef gboolean (*XbBuilderNodeTraverseFunc)(XbBuilderNode *bn, gpointer user_d
 typedef gint (*XbBuilderNodeSortFunc)(XbBuilderNode *bn1, XbBuilderNode *bn2, gpointer user_data);
 
 XbBuilderNode *
-xb_builder_node_new(const gchar *element);
+xb_builder_node_new(XbArena *arena, const gchar *element) G_GNUC_NON_NULL(1);
 XbBuilderNode *
-xb_builder_node_insert(XbBuilderNode *parent,
-		       const gchar *element,
-		       ...) G_GNUC_NULL_TERMINATED G_GNUC_WARN_UNUSED_RESULT G_GNUC_NON_NULL(2);
+xb_builder_node_insert(XbArena *arena, XbBuilderNode *parent, const gchar *element, ...)
+    G_GNUC_NULL_TERMINATED G_GNUC_WARN_UNUSED_RESULT G_GNUC_NON_NULL(1, 3);
 void
 xb_builder_node_insert_text(XbBuilderNode *parent, const gchar *element, const gchar *text, ...)
     G_GNUC_NULL_TERMINATED G_GNUC_NON_NULL(1, 2);
@@ -90,7 +90,7 @@ void
 xb_builder_node_add_child(XbBuilderNode *self, XbBuilderNode *child) G_GNUC_NON_NULL(2);
 void
 xb_builder_node_remove_child(XbBuilderNode *self, XbBuilderNode *child) G_GNUC_NON_NULL(1);
-GPtrArray *
+XbArenaPtrArray *
 xb_builder_node_get_children(XbBuilderNode *self) G_GNUC_NON_NULL(1);
 XbBuilderNode *
 xb_builder_node_get_first_child(XbBuilderNode *self) G_GNUC_NON_NULL(1);
@@ -103,6 +103,8 @@ void
 xb_builder_node_unlink(XbBuilderNode *self) G_GNUC_NON_NULL(1);
 XbBuilderNode *
 xb_builder_node_get_parent(XbBuilderNode *self) G_GNUC_NON_NULL(1);
+void
+xb_builder_node_remove_parent(XbBuilderNode *self) G_GNUC_NON_NULL(1);
 guint
 xb_builder_node_depth(XbBuilderNode *self) G_GNUC_NON_NULL(1);
 void
@@ -112,9 +114,6 @@ xb_builder_node_traverse(XbBuilderNode *self,
 			 gint max_depth,
 			 XbBuilderNodeTraverseFunc func,
 			 gpointer user_data) G_GNUC_NON_NULL(1, 5);
-void
-xb_builder_node_sort_children(XbBuilderNode *self, XbBuilderNodeSortFunc func, gpointer user_data)
-    G_GNUC_NON_NULL(1, 2);
 gchar *
 xb_builder_node_export(XbBuilderNode *self, XbNodeExportFlags flags, GError **error)
     G_GNUC_NON_NULL(1);

--- a/src/xb-builder-node.h
+++ b/src/xb-builder-node.h
@@ -9,23 +9,6 @@
 #include "xb-compile.h"
 #include "xb-node.h"
 
-G_BEGIN_DECLS
-
-#define XB_TYPE_BUILDER_NODE (xb_builder_node_get_type())
-G_DECLARE_DERIVABLE_TYPE(XbBuilderNode, xb_builder_node, XB, BUILDER_NODE, GObject)
-
-struct _XbBuilderNodeClass {
-	GObjectClass parent_class;
-	/*< private >*/
-	void (*_xb_reserved1)(void);
-	void (*_xb_reserved2)(void);
-	void (*_xb_reserved3)(void);
-	void (*_xb_reserved4)(void);
-	void (*_xb_reserved5)(void);
-	void (*_xb_reserved6)(void);
-	void (*_xb_reserved7)(void);
-};
-
 /**
  * XbBuilderNodeFlags:
  * @XB_BUILDER_NODE_FLAG_NONE:			No extra flags to use
@@ -50,6 +33,14 @@ typedef enum {
 	/*< private >*/
 	XB_BUILDER_NODE_FLAG_LAST
 } XbBuilderNodeFlags;
+
+/* XbBuilderNodes are deliberately not part of the GObject system. They are plain C structs
+ * this is because there are potentially tens of thousands of them and the overhead of GObject
+ * per-object RAM overhead and memory management becomes significant at that scale.
+ * Builder node objects are owned by a memory arena - see xb_arena.h
+ * In versions 0.3.22 and earler these were GObjects, and profiling showed this was the main
+ * bottleneck to parser performance. */
+typedef struct XbBuilderNode XbBuilderNode;
 
 typedef gboolean (*XbBuilderNodeTraverseFunc)(XbBuilderNode *bn, gpointer user_data);
 typedef gint (*XbBuilderNodeSortFunc)(XbBuilderNode *bn1, XbBuilderNode *bn2, gpointer user_data);
@@ -131,5 +122,3 @@ GPtrArray *
 xb_builder_node_get_tokens(XbBuilderNode *self) G_GNUC_NON_NULL(1);
 void
 xb_builder_node_add_token(XbBuilderNode *self, const gchar *token) G_GNUC_NON_NULL(1, 2);
-
-G_END_DECLS

--- a/src/xb-builder-source.c
+++ b/src/xb-builder-source.c
@@ -145,7 +145,7 @@ xb_builder_source_set_info(XbBuilderSource *self, XbBuilderNode *info)
 {
 	XbBuilderSourcePrivate *priv = GET_PRIVATE(self);
 	g_return_if_fail(XB_IS_BUILDER_SOURCE(self));
-	g_set_object(&priv->info, info);
+	priv->info = info;
 }
 
 /**
@@ -577,8 +577,6 @@ xb_builder_source_finalize(GObject *obj)
 
 	if (priv->istream != NULL)
 		g_object_unref(priv->istream);
-	if (priv->info != NULL)
-		g_object_unref(priv->info);
 	if (priv->file != NULL)
 		g_object_unref(priv->file);
 	g_ptr_array_unref(priv->fixups);

--- a/src/xb-self-test.c
+++ b/src/xb-self-test.c
@@ -823,7 +823,7 @@ xb_builder_node_vfunc_ignore_func(void)
 	g_autoptr(XbBuilder) builder = xb_builder_new();
 	g_autoptr(XbBuilderFixup) fixup = NULL;
 	g_autoptr(XbBuilderSource) source = xb_builder_source_new();
-	g_autoptr(XbBuilderNode) info = NULL;
+	XbBuilderNode *info = NULL;
 	g_autoptr(XbSilo) silo = NULL;
 	g_autoptr(XbNode) n = NULL;
 	g_autoptr(XbNode) c = NULL;
@@ -870,7 +870,7 @@ xb_builder_upgrade_appstream_cb(XbBuilderFixup *self,
 				GError **error)
 {
 	if (g_strcmp0(xb_builder_node_get_element(bn), "application") == 0) {
-		g_autoptr(XbBuilderNode) id = xb_builder_node_get_child(bn, "id", NULL);
+		XbBuilderNode *id = xb_builder_node_get_child(bn, "id", NULL);
 		g_autofree gchar *kind = NULL;
 		if (id != NULL) {
 			kind = g_strdup(xb_builder_node_get_attr(id, "type"));
@@ -932,7 +932,7 @@ xb_builder_fixup_ignore_node_cb(XbBuilderFixup *self,
 				GError **error)
 {
 	if (g_strcmp0(xb_builder_node_get_element(bn), "component") == 0) {
-		g_autoptr(XbBuilderNode) id = xb_builder_node_get_child(bn, "id", NULL);
+		XbBuilderNode *id = xb_builder_node_get_child(bn, "id", NULL);
 		if (id != NULL && g_strcmp0(xb_builder_node_get_text(id), "gimp.desktop") == 0)
 			xb_builder_node_add_flag(bn, XB_BUILDER_NODE_FLAG_IGNORE);
 	} else {
@@ -1766,8 +1766,8 @@ xb_manual_token_search_func(void)
 	XbNode *n;
 	g_autoptr(XbNode) cpt_node = NULL;
 	g_autoptr(XbBuilder) builder = NULL;
-	g_autoptr(XbBuilderNode) bn_root = NULL;
-	g_autoptr(XbBuilderNode) bn = NULL;
+	XbBuilderNode *bn_root = NULL;
+	XbBuilderNode *bn = NULL;
 	g_autoptr(XbSilo) silo = NULL;
 	g_autofree gchar *str = NULL;
 	g_autoptr(XbQuery) query = NULL;
@@ -2300,8 +2300,8 @@ xb_builder_node_token_max_func(void)
 	g_autofree gchar *xml = NULL;
 	g_autoptr(GError) error = NULL;
 	g_autoptr(XbBuilder) builder = xb_builder_new();
-	g_autoptr(XbBuilderNode) components = NULL;
-	g_autoptr(XbBuilderNode) root = xb_builder_node_new(NULL);
+	XbBuilderNode *components = NULL;
+	XbBuilderNode *root = xb_builder_node_new(NULL);
 	g_autoptr(XbSilo) silo = NULL;
 
 	/* create a simple document */
@@ -2331,15 +2331,15 @@ xb_builder_node_func(void)
 	g_autofree gchar *xml_src = NULL;
 	g_autoptr(GError) error = NULL;
 	g_autoptr(XbBuilder) builder = xb_builder_new();
-	g_autoptr(XbBuilderNode) child_by_element = NULL;
-	g_autoptr(XbBuilderNode) child_by_text = NULL;
-	g_autoptr(XbBuilderNode) component = NULL;
-	g_autoptr(XbBuilderNode) components = NULL;
-	g_autoptr(XbBuilderNode) id = NULL;
-	g_autoptr(XbBuilderNode) description = xb_builder_node_new("description");
-	g_autoptr(XbBuilderNode) em = xb_builder_node_new("em");
-	g_autoptr(XbBuilderNode) empty = NULL;
-	g_autoptr(XbBuilderNode) root = xb_builder_node_new(NULL);
+	XbBuilderNode *child_by_element = NULL;
+	XbBuilderNode *child_by_text = NULL;
+	XbBuilderNode *component = NULL;
+	XbBuilderNode *components = NULL;
+	XbBuilderNode *id = NULL;
+	XbBuilderNode *description = xb_builder_node_new("description");
+	XbBuilderNode *em = xb_builder_node_new("em");
+	XbBuilderNode *empty = NULL;
+	XbBuilderNode *root = xb_builder_node_new(NULL);
 	g_autoptr(XbSilo) silo = NULL;
 
 	/* create a simple document */
@@ -2514,8 +2514,8 @@ xb_builder_node_info_func(void)
 	g_autoptr(XbBuilderSource) import2 = xb_builder_source_new();
 	g_autoptr(XbBuilder) builder = xb_builder_new();
 	g_autoptr(XbNode) n = NULL;
-	g_autoptr(XbBuilderNode) info1 = NULL;
-	g_autoptr(XbBuilderNode) info2 = NULL;
+	XbBuilderNode *info1 = NULL;
+	XbBuilderNode *info2 = NULL;
 	g_autoptr(XbSilo) silo = NULL;
 	g_autoptr(GFile) file = NULL;
 


### PR DESCRIPTION
(WIP, it's my first time contributing so this is going to need some work. I'm sending this in a rough state to get eyes on it early.)

Resolves #244 

Moves all temporary allocations created by compiling an XML into a memory arena - primarily builder nodes and their children.

Sanity check: Compile the Fedora software catalog XML to XMLB with this tool before and after changes. Verify output is the same.

```
owen@owen-thinkpad:~/repos/libxmlb$ /usr/bin/time -v xb-tool compile before.xmlb fedora.xml.gz 
        Command being timed: "xb-tool compile before.xmlb fedora.xml.gz"
        User time (seconds): 0.89
        System time (seconds): 0.07
        Percent of CPU this job got: 99%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 0:00.97
        Average shared text size (kbytes): 0
        Average unshared data size (kbytes): 0
        Average stack size (kbytes): 0
        Average total size (kbytes): 0
        Maximum resident set size (kbytes): 172976
        Average resident set size (kbytes): 0
        Major (requiring I/O) page faults: 0
        Minor (reclaiming a frame) page faults: 41764
        Voluntary context switches: 7
        Involuntary context switches: 13
        Swaps: 0
        File system inputs: 0
        File system outputs: 21464
        Socket messages sent: 0
        Socket messages received: 0
        Signals delivered: 0
        Page size (bytes): 4096
        Exit status: 0
owen@owen-thinkpad:~/repos/libxmlb$ /usr/bin/time -v build/src/xb-tool compile after.xmlb fedora.xml.gz 
        Command being timed: "build/src/xb-tool compile after.xmlb fedora.xml.gz"
        User time (seconds): 0.44
        System time (seconds): 0.06
        Percent of CPU this job got: 99%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 0:00.51
        Average shared text size (kbytes): 0
        Average unshared data size (kbytes): 0
        Average stack size (kbytes): 0
        Average total size (kbytes): 0
        Maximum resident set size (kbytes): 135392
        Average resident set size (kbytes): 0
        Major (requiring I/O) page faults: 0
        Minor (reclaiming a frame) page faults: 32421
        Voluntary context switches: 9
        Involuntary context switches: 6
        Swaps: 0
        File system inputs: 0
        File system outputs: 21496
        Socket messages sent: 0
        Socket messages received: 0
        Signals delivered: 0
        Page size (bytes): 4096
        Exit status: 0
owen@owen-thinkpad:~/repos/libxmlb$ xb-tool export before.xmlb > /tmp/before.xml
owen@owen-thinkpad:~/repos/libxmlb$ xb-tool export after.xmlb > /tmp/after.xml
owen@owen-thinkpad:~/repos/libxmlb$ diff /tmp/before.xml /tmp/after.xml 
owen@owen-thinkpad:~/repos/libxmlb$
```

Summary: Identical output, 20% less peak RAM usage and 50% faster execution time. 

Heaptrack results on this parsing benchmark (github won't let me upload the raw profiles here)
* Before changes: 3.29 million heap allocations
* After changes: 0.04 million heap allocations

More important than total RAM usage, these are now the type of allocation that glibc's malloc implementation can easily release back to the OS when compilation is complete. So this should really improve allocator pressure and heap fragmentation when libxmlb compile functions are called in a long-lived program.

Still needs work:
* This necessarily changes the public API around builder nodes. You can't just heap allocate them as GObjects now. A search showed code that uses this part of the API is very rare. The only thing I could find that depended on it was one function in the gnome-software appstream plugin. But it's still an API break and a rollout concern.
* I'm getting warnings about .gir file generation related to the public API change. Could use some help fixing that.
* (Cleanup) unit tests, formatting