### PR TITLE
trivial: Fix invalid escape sequence due to missing r prefix

### DIFF
--- a/src/gen-def-from-map.py
+++ b/src/gen-def-from-map.py
@@ -30,7 +30,7 @@ def get_sym_groups(lines, namespace):
     # Look, if any, since which version were the symbols
     # group added
     ending_notail_regex = re.compile(r"^};\s+$")
-    ending_tail_regex = re.compile(r"^}\s+" + namespace_with_ver_regex + ";\s+$")
+    ending_tail_regex = re.compile(r"^}\s+" + namespace_with_ver_regex + r";\s+$")
 
     for l in lines:
         # New symbols group found in map file


### PR DESCRIPTION
    libxmlb/src/gen-def-from-map.py:33: SyntaxWarning: "\s" is an invalid
    escape sequence. Such sequences will not work in the future. Did you
    mean "\\s"? A raw string is also an option.