### PR TITLE
Do not construct an invalid silo when the XML component has >= 30 attributes

### DIFF
--- a/src/xb-silo-node.h
+++ b/src/xb-silo-node.h
@@ -50,7 +50,7 @@ static inline guint32
 xb_silo_node_get_size(const XbSiloNode *self)
 {
 	if (xb_silo_node_has_flag(self, XB_SILO_NODE_FLAG_IS_ELEMENT)) {
-		guint8 sz = sizeof(XbSiloNode);
+		guint32 sz = sizeof(XbSiloNode);
 		sz += self->attr_count * sizeof(XbSiloNodeAttr);
 		sz += self->token_count * sizeof(guint32);
 		return sz;


### PR DESCRIPTION
Spotted by Ali Raza <elirazamumtaz@gmail.com>, many thanks.

This resolves the incomplete fix in 3529685.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a serialization size computation issue that could cause data truncation for larger node objects.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hughsie/libxmlb/pull/307)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->