### PR TITLE
trivial: Mark xb_string_escape() as deprecated

### DIFF
--- a/src/xb-string.h
+++ b/src/xb-string.h
@@ -13,6 +13,8 @@ G_BEGIN_DECLS
 void
 xb_string_append_union(GString *xpath, const gchar *fmt, ...) G_GNUC_PRINTF(2, 3)
     G_GNUC_NON_NULL(1);
+
+GLIB_DEPRECATED_FOR(xb_value_bindings_bind_str)
 gchar *
 xb_string_escape(const gchar *str) G_GNUC_NON_NULL(1);
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Deprecated a string utility function. Developers should migrate to the recommended alternative.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hughsie/libxmlb/pull/309?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->