### PR TITLE
Fix use-after-free in xb_machine_func_in_cb haystack building

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -129,8 +129,8 @@ else
 endif
 mandir = join_paths(prefix, get_option('mandir'))
 
-gio = dependency('gio-2.0', version : '>= 2.45.8')
-giounix = dependency('gio-unix-2.0', version : '>= 2.45.8', required: false)
+gio = dependency('gio-2.0', version : '>= 2.68.0')
+giounix = dependency('gio-unix-2.0', required: false)
 lzma = dependency('liblzma', required: get_option('lzma'))
 if lzma.found()
   conf.set('HAVE_LZMA', 1)
@@ -144,10 +144,10 @@ if giounix.found()
 endif
 
 # Limit our use of GLib API to our minimum version requirement, and what’s
-# available in Debian Stable. Use of more modern API has to be optional and
+# available in RHEL 9. Use of more modern API has to be optional and
 # protected by GLIB_CHECK_VERSION.
 add_project_arguments('-DGLIB_VERSION_MIN_REQUIRED=GLIB_VERSION_2_46', language: 'c')
-add_project_arguments('-DGLIB_VERSION_MAX_ALLOWED=GLIB_VERSION_2_58', language: 'c')
+add_project_arguments('-DGLIB_VERSION_MAX_ALLOWED=GLIB_VERSION_2_68', language: 'c')
 
 libxmlb_deps = [
   gio,

--- a/src/libxmlb.map
+++ b/src/libxmlb.map
@@ -276,3 +276,9 @@ LIBXMLB_0.3.19 {
     xb_version_string;
   local: *;
 } LIBXMLB_0.3.4;
+
+LIBXMLB_0.3.27 {
+  global:
+    xb_silo_lookup_query_full;
+  local: *;
+} LIBXMLB_0.3.19;

--- a/src/xb-machine.c
+++ b/src/xb-machine.c
@@ -11,10 +11,6 @@
 #include <gio/gio.h>
 #include <string.h>
 
-#if !GLIB_CHECK_VERSION(2, 54, 0)
-#include <errno.h>
-#endif
-
 #include "xb-machine-private.h"
 #include "xb-opcode-private.h"
 #include "xb-silo-private.h"
@@ -291,80 +287,6 @@ xb_machine_parse_add_func(XbMachine *self,
 
 	return TRUE;
 }
-
-#if !GLIB_CHECK_VERSION(2, 54, 0)
-static gboolean
-str_has_sign(const gchar *str)
-{
-	return str[0] == '-' || str[0] == '+';
-}
-
-static gboolean
-str_has_hex_prefix(const gchar *str)
-{
-	return str[0] == '0' && g_ascii_tolower(str[1]) == 'x';
-}
-
-static gboolean
-g_ascii_string_to_unsigned(const gchar *str,
-			   guint base,
-			   guint64 min,
-			   guint64 max,
-			   guint64 *out_num,
-			   GError **error)
-{
-	const gchar *end_ptr = NULL;
-	gint saved_errno = 0;
-	guint64 number;
-
-	g_return_val_if_fail(str != NULL, FALSE);
-	g_return_val_if_fail(base >= 2 && base <= 36, FALSE);
-	g_return_val_if_fail(min <= max, FALSE);
-	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
-
-	if (str[0] == '\0') {
-		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
-				    "Empty string is not a number");
-		return FALSE;
-	}
-
-	errno = 0;
-	number = g_ascii_strtoull(str, (gchar **)&end_ptr, base);
-	saved_errno = errno;
-
-	if (g_ascii_isspace(str[0]) || str_has_sign(str) ||
-	    (base == 16 && str_has_hex_prefix(str)) ||
-	    (saved_errno != 0 && saved_errno != ERANGE) || end_ptr == NULL || *end_ptr != '\0') {
-		if (error != NULL) {
-			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
-				    "“%s” is not an unsigned number",
-				    str);
-		}
-		return FALSE;
-	}
-	if (saved_errno == ERANGE || number < min || number > max) {
-		if (error != NULL) {
-			g_autofree gchar *min_str = g_strdup_printf("%" G_GUINT64_FORMAT, min);
-			g_autofree gchar *max_str = g_strdup_printf("%" G_GUINT64_FORMAT, max);
-			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
-				    "Number “%s” is out of bounds [%s, %s]",
-				    str,
-				    min_str,
-				    max_str);
-		}
-		return FALSE;
-	}
-	if (out_num != NULL)
-		*out_num = number;
-	return TRUE;
-}
-#endif
 
 static gboolean
 xb_machine_parse_add_text(XbMachine *self,

--- a/src/xb-machine.c
+++ b/src/xb-machine.c
@@ -2392,6 +2392,10 @@ xb_machine_func_in_cb(XbMachine *self,
 	if (!xb_machine_stack_pop(self, stack, &op, error))
 		return FALSE;
 
+	/* a NULL needle (e.g. from a missing attribute) can never match */
+	if (_xb_opcode_get_str(&op) == NULL)
+		return xb_stack_push_bool(stack, FALSE, error);
+
 	/* found */
 	for (guint i = 0; i < nr_args; i++) {
 		if (g_strcmp0(haystack[i], _xb_opcode_get_str(&op)) == 0)

--- a/src/xb-machine.c
+++ b/src/xb-machine.c
@@ -63,6 +63,20 @@ typedef struct {
 
 #define XB_MACHINE_STACK_LEVELS_MAX 20
 
+typedef struct {
+	XbOpcode ops[XB_MACHINE_STACK_LEVELS_MAX];
+	guint len;
+} XbOpcodeArray;
+
+static inline void
+xb_opcode_array_clear(XbOpcodeArray *self)
+{
+	for (guint i = 0; i < self->len; i++)
+		xb_opcode_clear(&self->ops[i]);
+}
+
+G_DEFINE_AUTO_CLEANUP_CLEAR_FUNC(XbOpcodeArray, xb_opcode_array_clear)
+
 /**
  * xb_machine_set_debug_flags:
  * @self: a #XbMachine
@@ -2308,6 +2322,7 @@ xb_machine_func_in_cb(XbMachine *self,
 	XbOpcode *op_needle;
 	const gchar *haystack[XB_MACHINE_STACK_LEVELS_MAX + 1] = {NULL};
 	g_auto(XbOpcode) op = XB_OPCODE_INIT();
+	g_auto(XbOpcodeArray) haystack_ops = {.len = 0};
 	guint8 level = G_MAXUINT8;
 	guint nr_args = 0;
 
@@ -2367,10 +2382,10 @@ xb_machine_func_in_cb(XbMachine *self,
 
 	/* build the haystack */
 	for (guint i = 0; i < nr_args; i++) {
-		g_auto(XbOpcode) op_tmp = XB_OPCODE_INIT();
-		if (!xb_machine_stack_pop(self, stack, &op_tmp, error))
+		if (!xb_machine_stack_pop(self, stack, &haystack_ops.ops[i], error))
 			return FALSE;
-		haystack[i] = _xb_opcode_get_str(&op_tmp);
+		haystack_ops.len++;
+		haystack[i] = _xb_opcode_get_str(&haystack_ops.ops[i]);
 	}
 
 	/* get the needle */
@@ -2378,7 +2393,11 @@ xb_machine_func_in_cb(XbMachine *self,
 		return FALSE;
 
 	/* found */
-	return xb_stack_push_bool(stack, g_strv_contains(haystack, _xb_opcode_get_str(&op)), error);
+	for (guint i = 0; i < nr_args; i++) {
+		if (g_strcmp0(haystack[i], _xb_opcode_get_str(&op)) == 0)
+			return xb_stack_push_bool(stack, TRUE, error);
+	}
+	return xb_stack_push_bool(stack, FALSE, error);
 }
 
 static void

--- a/src/xb-self-test.c
+++ b/src/xb-self-test.c
@@ -1856,6 +1856,39 @@ xb_xpath_in_func(void)
 }
 
 static void
+xb_xpath_in_lower_func(void)
+{
+	XbNode *n;
+	gboolean ret;
+	g_autoptr(GError) error = NULL;
+	g_autoptr(XbBuilder) builder = xb_builder_new();
+	g_autoptr(XbBuilderSource) source = xb_builder_source_new();
+	g_autoptr(XbSilo) silo = NULL;
+	const gchar *xml = "<component><id>test</id></component>\n";
+
+	ret = xb_builder_source_load_xml(source, xml, XB_BUILDER_SOURCE_FLAG_NONE, &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+	xb_builder_import_source(builder, source);
+	silo = xb_builder_compile(builder, XB_BUILDER_COMPILE_FLAG_NONE, NULL, &error);
+	g_assert_no_error(error);
+	g_assert_nonnull(silo);
+
+	/* in() with lower-case() should match */
+	n = xb_silo_query_first(silo, "component/id[in(text(),lower-case('TEST'))]", &error);
+	g_assert_no_error(error);
+	g_assert_nonnull(n);
+	g_assert_cmpstr(xb_node_get_text(n), ==, "test");
+	g_clear_object(&n);
+
+	/* in() with lower-case() no match */
+	n = xb_silo_query_first(silo, "component/id[in(text(),lower-case('NOPE'))]", &error);
+	g_assert_error(error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND);
+	g_assert_null(n);
+	g_clear_error(&error);
+}
+
+static void
 xb_xpath_stem_func(void)
 {
 	XbNode *n;
@@ -3291,6 +3324,7 @@ main(int argc, char **argv)
 	g_test_add_func("/libxmlb/xpath", xb_xpath_func);
 	g_test_add_func("/libxmlb/xpath{null-attr}", xb_xpath_null_attr_func);
 	g_test_add_func("/libxmlb/xpath{in}", xb_xpath_in_func);
+	g_test_add_func("/libxmlb/xpath{in-lower}", xb_xpath_in_lower_func);
 	g_test_add_func("/libxmlb/xpath{stem}", xb_xpath_stem_func);
 	g_test_add_func("/libxmlb/xpath{or-limit}", xb_xpath_or_limit_func);
 	g_test_add_func("/libxmlb/xpath{operator-depth-limit}", xb_xpath_operator_depth_limit_func);

--- a/src/xb-self-test.c
+++ b/src/xb-self-test.c
@@ -1889,6 +1889,40 @@ xb_xpath_in_lower_func(void)
 }
 
 static void
+xb_xpath_in_null_needle_func(void)
+{
+	XbNode *n;
+	gboolean ret;
+	g_autoptr(GError) error = NULL;
+	g_autoptr(XbBuilder) builder = xb_builder_new();
+	g_autoptr(XbBuilderSource) source = xb_builder_source_new();
+	g_autoptr(XbSilo) silo = NULL;
+	const gchar *xml = "<component><id>test</id></component>\n";
+
+	ret = xb_builder_source_load_xml(source, xml, XB_BUILDER_SOURCE_FLAG_NONE, &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+	xb_builder_import_source(builder, source);
+	silo = xb_builder_compile(builder, XB_BUILDER_COMPILE_FLAG_NONE, NULL, &error);
+	g_assert_no_error(error);
+	g_assert_nonnull(silo);
+
+	/* in() with a missing attribute (NULL needle) should not crash */
+	n = xb_silo_query_first(silo, "component/id[attr('missing')=('a','b')]", &error);
+	g_assert_error(error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND);
+	g_assert_null(n);
+	g_clear_error(&error);
+
+	/* in() with a NULL haystack entry (from attr on missing attribute) should not crash */
+	n = xb_silo_query_first(silo,
+				"component/id[in(text(),lower-case(attr('missing')))]",
+				&error);
+	g_assert_error(error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND);
+	g_assert_null(n);
+	g_clear_error(&error);
+}
+
+static void
 xb_xpath_stem_func(void)
 {
 	XbNode *n;
@@ -3325,6 +3359,7 @@ main(int argc, char **argv)
 	g_test_add_func("/libxmlb/xpath{null-attr}", xb_xpath_null_attr_func);
 	g_test_add_func("/libxmlb/xpath{in}", xb_xpath_in_func);
 	g_test_add_func("/libxmlb/xpath{in-lower}", xb_xpath_in_lower_func);
+	g_test_add_func("/libxmlb/xpath{in-null-needle}", xb_xpath_in_null_needle_func);
 	g_test_add_func("/libxmlb/xpath{stem}", xb_xpath_stem_func);
 	g_test_add_func("/libxmlb/xpath{or-limit}", xb_xpath_or_limit_func);
 	g_test_add_func("/libxmlb/xpath{operator-depth-limit}", xb_xpath_operator_depth_limit_func);

--- a/src/xb-silo.c
+++ b/src/xb-silo.c
@@ -1913,9 +1913,10 @@ xb_silo_new(void)
 }
 
 /**
- * xb_silo_lookup_query:
+ * xb_silo_lookup_query_full:
  * @self: an #XbSilo
  * @xpath: an XPath query string
+ * @error: the #GError, or %NULL
  *
  * Create an #XbQuery from the given @xpath XPath string, or return it from the
  * query cache in the #XbSilo.
@@ -1926,13 +1927,17 @@ xb_silo_new(void)
  * This function is thread-safe.
  *
  * Returns: (transfer full): an #XbQuery representing @xpath
- * Since: 0.3.0
+ *
+ * Since: 0.3.27
  */
 XbQuery *
-xb_silo_lookup_query(XbSilo *self, const gchar *xpath)
+xb_silo_lookup_query_full(XbSilo *self, const gchar *xpath, GError **error)
 {
 	XbSiloPrivate *priv = GET_PRIVATE(self);
 	XbQuery *result;
+
+	g_return_val_if_fail(XB_IS_SILO(self), NULL);
+	g_return_val_if_fail(error == NULL || *error == NULL, NULL);
 
 	g_rw_lock_reader_lock(&priv->query_cache_mutex);
 	result = g_hash_table_lookup(priv->query_cache, xpath);
@@ -1949,17 +1954,9 @@ xb_silo_lookup_query(XbSilo *self, const gchar *xpath)
 		if (result != NULL) {
 			g_object_ref(result);
 		} else {
-			g_autoptr(GError) error_local = NULL;
-
-			query = xb_query_new(self, xpath, &error_local);
+			query = xb_query_new(self, xpath, error);
 			if (query == NULL) {
-				/* This should not happen: the caller should
-				 * have written a valid query. */
-				g_error("Invalid XPath query ‘%s’: %s",
-					xpath,
-					error_local->message);
 				g_rw_lock_writer_unlock(&priv->query_cache_mutex);
-				g_assert_not_reached();
 				return NULL;
 			}
 
@@ -1979,4 +1976,35 @@ xb_silo_lookup_query(XbSilo *self, const gchar *xpath)
 	}
 
 	return result;
+}
+
+/**
+ * xb_silo_lookup_query:
+ * @self: an #XbSilo
+ * @xpath: an XPath query string
+ *
+ * Create an #XbQuery from the given @xpath XPath string, or return it from the
+ * query cache in the #XbSilo.
+ *
+ * @xpath must be valid: it is a programmer error if creating the query fails
+ * (i.e. if xb_query_new() returns an error).
+ *
+ * This function is thread-safe.
+ *
+ * Returns: (transfer full): an #XbQuery representing @xpath
+ *
+ * Since: 0.3.0
+ */
+XbQuery *
+xb_silo_lookup_query(XbSilo *self, const gchar *xpath)
+{
+	g_autoptr(GError) error = NULL;
+	g_autoptr(XbQuery) query = NULL;
+
+	query = xb_silo_lookup_query_full(self, xpath, &error);
+	if (query == NULL) {
+		g_warning("failed: %s", error->message);
+		return NULL;
+	}
+	return g_steal_pointer(&query);
 }

--- a/src/xb-silo.c
+++ b/src/xb-silo.c
@@ -1934,48 +1934,32 @@ XbQuery *
 xb_silo_lookup_query_full(XbSilo *self, const gchar *xpath, GError **error)
 {
 	XbSiloPrivate *priv = GET_PRIVATE(self);
-	XbQuery *result;
+	XbQuery *query;
+	g_autoptr(GRWLockReaderLocker) locker_ro = NULL;
+	g_autoptr(GRWLockWriterLocker) locker_rw = NULL;
 
 	g_return_val_if_fail(XB_IS_SILO(self), NULL);
 	g_return_val_if_fail(error == NULL || *error == NULL, NULL);
 
-	g_rw_lock_reader_lock(&priv->query_cache_mutex);
-	result = g_hash_table_lookup(priv->query_cache, xpath);
-	g_rw_lock_reader_unlock(&priv->query_cache_mutex);
+	/* read only */
+	locker_ro = g_rw_lock_reader_locker_new(&priv->query_cache_mutex);
+	query = g_hash_table_lookup(priv->query_cache, xpath);
+	if (query != NULL)
+		return g_object_ref(query);
+	g_clear_pointer(&locker_ro, g_rw_lock_reader_locker_free);
 
-	if (result != NULL) {
-		g_object_ref(result);
-	} else {
-		g_autoptr(XbQuery) query = NULL;
+	/* check again with an exclusive lock */
+	locker_rw = g_rw_lock_writer_locker_new(&priv->query_cache_mutex);
+	query = g_hash_table_lookup(priv->query_cache, xpath);
+	if (query != NULL)
+		return g_object_ref(query);
 
-		/* check again with an exclusive lock */
-		g_rw_lock_writer_lock(&priv->query_cache_mutex);
-		result = g_hash_table_lookup(priv->query_cache, xpath);
-		if (result != NULL) {
-			g_object_ref(result);
-		} else {
-			query = xb_query_new(self, xpath, error);
-			if (query == NULL) {
-				g_rw_lock_writer_unlock(&priv->query_cache_mutex);
-				return NULL;
-			}
-
-			result = g_object_ref(query);
-
-			g_hash_table_insert(priv->query_cache,
-					    g_strdup(xpath),
-					    g_steal_pointer(&query));
-			g_debug(
-			    "Caching query ‘%s’ (%p) in silo %p; query cache now has %u entries",
-			    xpath,
-			    query,
-			    self,
-			    g_hash_table_size(priv->query_cache));
-		}
-		g_rw_lock_writer_unlock(&priv->query_cache_mutex);
-	}
-
-	return result;
+	/* add it */
+	query = xb_query_new(self, xpath, error);
+	if (query == NULL)
+		return NULL;
+	g_hash_table_insert(priv->query_cache, g_strdup(xpath), g_object_ref(query));
+	return query;
 }
 
 /**

--- a/src/xb-silo.h
+++ b/src/xb-silo.h
@@ -110,7 +110,10 @@ xb_silo_set_enable_node_cache(XbSilo *self, gboolean enable_node_cache) G_GNUC_N
 
 #include "xb-query.h"
 
+G_DEPRECATED_FOR(xb_silo_lookup_query_full)
 XbQuery *
 xb_silo_lookup_query(XbSilo *self, const gchar *xpath) G_GNUC_NON_NULL(1, 2);
+XbQuery *
+xb_silo_lookup_query_full(XbSilo *self, const gchar *xpath, GError **error) G_GNUC_NON_NULL(1, 2);
 
 G_END_DECLS


### PR DESCRIPTION
When in() pops opcodes that own their strings (e.g. from lower-case()), the per-iteration g_auto(XbOpcode) frees the string at the end of each loop iteration while the haystack array still references it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added tests for XPath in() with transformed text and missing-needle cases.

* **Bug Fixes**
  * in() now returns "not found" for absent/null needles instead of erroring.

* **Refactor**
  * Streamlined in() predicate processing for reduced allocations and clearer logic; removed legacy fallback code paths.

* **Chores**
  * Added a new query-lookup API and deprecated the old one (now fails gracefully with a warning).
  * Updated GLib/build version constraints.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hughsie/libxmlb/pull/310?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->