### PR TITLE
Lower the Meson and GLib deps for RHEL-8

### DIFF
--- a/contrib/libxmlb.spec.in
+++ b/contrib/libxmlb.spec.in
@@ -1,6 +1,4 @@
-%bcond stemmer %{defined fedora}
-
-%global glib2_version 2.45.8
+%global glib2_version 2.56.0
 
 %define alphatag                #ALPHATAG#
 
@@ -14,7 +12,7 @@ Source0:   https://github.com/hughsie/%{name}/releases/download/%{version}/%{nam
 
 BuildRequires: glib2-devel >= %{glib2_version}
 BuildRequires: gtk-doc
-%if %{with stemmer}
+%if 0%{?fedora}
 BuildRequires: libstemmer-devel
 %endif
 BuildRequires: meson

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project('libxmlb', 'c',
   version : '0.3.28',
   license : 'LGPL-2.1-or-later',
-  meson_version : '>=0.60.0',
+  meson_version : '>=0.58.2',
   default_options : ['warning_level=2', 'c_std=c99'],
 )
 
@@ -129,7 +129,7 @@ else
 endif
 mandir = join_paths(prefix, get_option('mandir'))
 
-gio = dependency('gio-2.0', version : '>= 2.68.0')
+gio = dependency('gio-2.0', version : '>= 2.56.0')
 giounix = dependency('gio-unix-2.0', required: false)
 lzma = dependency('liblzma', required: get_option('lzma'))
 if lzma.found()
@@ -142,12 +142,6 @@ endif
 if giounix.found()
   conf.set('HAVE_GIO_UNIX', '1')
 endif
-
-# Limit our use of GLib API to our minimum version requirement, and what’s
-# available in RHEL 9. Use of more modern API has to be optional and
-# protected by GLIB_CHECK_VERSION.
-add_project_arguments('-DGLIB_VERSION_MIN_REQUIRED=GLIB_VERSION_2_46', language: 'c')
-add_project_arguments('-DGLIB_VERSION_MAX_ALLOWED=GLIB_VERSION_2_68', language: 'c')
 
 libxmlb_deps = [
   gio,

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -10,8 +10,4 @@ option('lzma',
 option('zstd',
   type: 'feature',
   description: 'enable zstd support',
-  deprecated: {
-    'true': 'enabled',
-    'false': 'disabled',
-  },
 )

--- a/src/meson.build
+++ b/src/meson.build
@@ -16,6 +16,7 @@ xb_headers = files(
   'xb-builder-source.h',
   'xb-builder-source-ctx.h',
   'xb-compile.h',
+  'xb-compile-glib-2-62.h',
   'xb-machine.h',
   'xb-node.h',
   'xb-node-query.h',

--- a/src/xb-compile-glib-2-62.h
+++ b/src/xb-compile-glib-2-62.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2026 Richard Hughes <richard@hughsie.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#pragma once
+
+#include <glib.h>
+
+typedef void GRWLockReaderLocker;
+
+static inline GRWLockReaderLocker *
+g_rw_lock_reader_locker_new(GRWLock *rw_lock)
+{
+	g_rw_lock_reader_lock(rw_lock);
+	return (GRWLockReaderLocker *)rw_lock;
+}
+
+static inline void
+g_rw_lock_reader_locker_free(GRWLockReaderLocker *locker)
+{
+	g_rw_lock_reader_unlock((GRWLock *)locker);
+}
+
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GRWLockReaderLocker, g_rw_lock_reader_locker_free)
+
+typedef void GRWLockWriterLocker;
+
+static inline GRWLockWriterLocker *
+g_rw_lock_writer_locker_new(GRWLock *rw_lock)
+{
+	g_rw_lock_writer_lock(rw_lock);
+	return (GRWLockWriterLocker *)rw_lock;
+}
+
+static inline void
+g_rw_lock_writer_locker_free(GRWLockWriterLocker *locker)
+{
+	g_rw_lock_writer_unlock((GRWLock *)locker);
+}
+
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GRWLockWriterLocker, g_rw_lock_writer_locker_free)

--- a/src/xb-compile.h
+++ b/src/xb-compile.h
@@ -16,3 +16,7 @@
 #define G_GNUC_NON_NULL(params...)
 #endif
 #endif
+
+#if !GLIB_CHECK_VERSION(2, 62, 0)
+#include "xb-compile-glib-2-62.h"
+#endif

--- a/src/xb-silo-node.c
+++ b/src/xb-silo-node.c
@@ -11,8 +11,8 @@ gchar *
 xb_silo_node_to_string(const XbSiloNode *self)
 {
 	GString *str = g_string_new("XbSiloNode:\n");
-	g_string_append_printf(str, "  flags: 0x%x\n", self->flags);
-	g_string_append_printf(str, "  attr_count: %u\n", self->attr_count);
+	g_string_append_printf(str, "  flags: 0x%x\n", (guint)self->flags);
+	g_string_append_printf(str, "  attr_count: %u\n", (guint)self->attr_count);
 	if (self->flags & XB_SILO_NODE_FLAG_IS_ELEMENT) {
 		if (self->element_name != XB_SILO_UNSET)
 			g_string_append_printf(str, "  element_name: %u\n", self->element_name);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added thread-safe locking utilities with automatic resource cleanup for reader/writer locks.

* **Chores**
  * Lowered minimum version requirements for build tools and GLib dependencies to support broader platform compatibility.
  * Simplified build configuration by removing deprecated option mappings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hughsie/libxmlb/pull/313?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->