### PR TITLE
trivial: Use lt_current rather than hardcoding the soname directory name

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -6,7 +6,7 @@ libxmlb_version_h = configure_file(
 
 install_headers(
   'xmlb.h',
-  subdir : 'libxmlb-2',
+  subdir : 'libxmlb-@0@'.format(lt_current),
 )
 
 xb_headers = files(
@@ -34,7 +34,7 @@ xb_headers = files(
 
 install_headers(
   xb_headers,
-  subdir : 'libxmlb-2/libxmlb',
+  subdir : 'libxmlb-@0@/libxmlb'.format(lt_current),
 )
 
 subdir('libxmlb')
@@ -139,7 +139,7 @@ endif
 pkgg = import('pkgconfig')
 pkgg.generate(libxmlb,
   requires : [ 'gio-2.0' ],
-  subdirs : 'libxmlb-2',
+  subdirs : 'libxmlb-@0@'.format(lt_current),
   version : meson.project_version(),
   name : 'libxmlb',
   filebase : 'xmlb',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated installed header and pkg-config locations to use a versioned subdirectory consistently, improving compatibility across library versions.
  * Ensured generated build metadata points to the same version-aware path as installed headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->