### PR TITLE
Fix building the silo when shared-mime-info is installed

### DIFF
--- a/src/xb-builder-source.c
+++ b/src/xb-builder-source.c
@@ -469,7 +469,7 @@ xb_builder_source_get_istream(XbBuilderSource *self, GCancellable *cancellable, 
 		g_debug("detected content type of %s to be %s", basename, content_type);
 		if (content_type == NULL)
 			return NULL;
-		if (g_strcmp0(content_type, "application/xml") == 0)
+		if (g_content_type_is_a(content_type, "application/xml"))
 			break;
 		/* Also accept the text/xml alias, just in case the user’s content-type database is
 		 * slightly broken (application/xml should normally be what’s used): */


### PR DESCRIPTION
shared-mime-info 2.5.1 added a `application/x-freedesktop-appstream-component` that is a subclass of `application/xml` -- which breaks the explicit content type checks in the source builder. Abort the loop for any XML subclass instead to cover both cases.

Fixes: https://github.com/hughsie/libxmlb/issues/325

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved XML content detection so files identified as `application/xml` are handled correctly.
  * Preserved support for `text/xml` and compressed XML processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->