### PR TITLE
Correctly mark the silo as invalid when re-loading malformed data

### DIFF
--- a/src/xb-silo.c
+++ b/src/xb-silo.c
@@ -758,6 +758,7 @@ xb_silo_load_from_bytes(XbSilo *self, GBytes *blob, XbSiloLoadFlags flags, GErro
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
 	/* no longer valid */
+	xb_silo_invalidate(self);
 	if (priv->enable_node_cache) {
 		locker = g_mutex_locker_new(&priv->nodes_mutex);
 		if (priv->nodes != NULL)
@@ -847,7 +848,7 @@ xb_silo_load_from_bytes(XbSilo *self, GBytes *blob, XbSiloLoadFlags flags, GErro
 	xb_silo_add_profile(self, timer, "parse blob");
 
 	/* success */
-	priv->valid = TRUE;
+	xb_silo_uninvalidate(self);
 	return TRUE;
 }
 


### PR DESCRIPTION
Found by Aisle Research; many thanks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved silo reload handling so validity updates are consistently notified.
  * Prevented stale validity states during loading, improving reliability when refreshing silo data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->