### PR TITLE
Fix a potential out of bounds read when building a XbBuilderNode

### DIFF
--- a/src/xb-builder-node.c
+++ b/src/xb-builder-node.c
@@ -12,6 +12,7 @@
 #include <string.h>
 
 #include "xb-builder-node-private.h"
+#include "xb-common-private.h"
 #include "xb-opcode-private.h"
 #include "xb-silo-private.h"
 #include "xb-string-private.h"
@@ -277,7 +278,7 @@ xb_builder_node_parse_literal_text(XbBuilderNode *self, const gchar *text, gssiz
 
 	/* split the text into lines */
 	tmp = g_string_sized_new((gsize)text_len_safe + 1);
-	split = g_strsplit(text, "\n", -1);
+	split = xb_strsplit(text, text_len_safe, "\n", -1);
 	for (guint i = 0; split[i] != NULL; i++) {
 		/* if this is a blank line we end the paragraph mode
 		 * and swallow the newline. If we see exactly two

--- a/src/xb-common-private.h
+++ b/src/xb-common-private.h
@@ -16,3 +16,5 @@ xb_file_set_contents(GFile *file,
 		     gsize bufsz,
 		     GCancellable *cancellable,
 		     GError **error) G_GNUC_NON_NULL(1);
+gchar **
+xb_strsplit(const gchar *str, gsize sz, const gchar *delimiter, gint max_tokens) G_GNUC_NON_NULL(1);

--- a/src/xb-common.c
+++ b/src/xb-common.c
@@ -141,3 +141,28 @@ xb_file_set_contents(GFile *file,
 				       cancellable,
 				       error);
 }
+
+/**
+ * xb_strsplit:
+ * @str: (not nullable): a string to split
+ * @sz: size of @str, which must be more than 0
+ * @delimiter: a string which specifies the places at which to split the string
+ * @max_tokens: the maximum number of pieces to split @str into
+ *
+ * Splits a string into a maximum of @max_tokens pieces, using the given
+ * delimiter. If @max_tokens is reached, the remainder of string is appended
+ * to the last token.
+ *
+ * Returns: (transfer full): a newly-allocated NULL-terminated array of strings
+ **/
+gchar **
+xb_strsplit(const gchar *str, gsize sz, const gchar *delimiter, gint max_tokens)
+{
+	g_return_val_if_fail(str != NULL, NULL);
+	g_return_val_if_fail(sz > 0, NULL);
+	if (str[sz - 1] != '\0') {
+		g_autofree gchar *str2 = g_strndup(str, sz);
+		return g_strsplit(str2, delimiter, max_tokens);
+	}
+	return g_strsplit(str, delimiter, max_tokens);
+}

--- a/src/xb-self-test.c
+++ b/src/xb-self-test.c
@@ -2696,6 +2696,20 @@ xb_builder_node_token_max_func(void)
 }
 
 static void
+xb_builder_node_nul_func(void)
+{
+	const gchar buf[] = {'A', '\n', 'B'};
+	g_autoptr(XbBuilderNode) root = xb_builder_node_new(NULL);
+
+	xb_builder_node_set_text(root, "\n", 0);
+	g_assert_cmpstr(xb_builder_node_get_text(root), ==, NULL);
+	xb_builder_node_set_text(root, "dave", -1);
+	g_assert_cmpstr(xb_builder_node_get_text(root), ==, "dave");
+	xb_builder_node_set_text(root, buf, sizeof(buf));
+	g_assert_cmpstr(xb_builder_node_get_text(root), ==, "A B");
+}
+
+static void
 xb_builder_node_func(void)
 {
 	g_autofree gchar *xml = NULL;
@@ -3372,6 +3386,7 @@ main(int argc, char **argv)
 	g_test_add_func("/libxmlb/builder{source-lzma}", xb_builder_source_lzma_func);
 	g_test_add_func("/libxmlb/builder{source-zstd}", xb_builder_source_zstd_func);
 	g_test_add_func("/libxmlb/builder-node", xb_builder_node_func);
+	g_test_add_func("/libxmlb/builder-node/nul", xb_builder_node_nul_func);
 	g_test_add_func("/libxmlb/builder-node{token-max}", xb_builder_node_token_max_func);
 	g_test_add_func("/libxmlb/builder-node{info}", xb_builder_node_info_func);
 	g_test_add_func("/libxmlb/builder-node{literal-text}", xb_builder_node_literal_text_func);


### PR DESCRIPTION
Although xb_builder_node_set_text() is normally NUL-terminated, it doesn't have to be. Split the string taking into account the possibility that NUL is missing.

Found by Aisle Research, many thanks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of length-limited text input, including buffers that are not NUL-terminated.
  * Preserved embedded newline content when processing builder-node text.

* **Tests**
  * Added coverage for zero-length input, NUL-terminated strings and embedded newline data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->